### PR TITLE
Fix cryptic 'lost sys.stdin' error with informative auth message

### DIFF
--- a/nasa_opera/dialogs/opera_dock.py
+++ b/nasa_opera/dialogs/opera_dock.py
@@ -106,6 +106,26 @@ OPERA_DATASETS = {
 }
 
 
+def _earthdata_login():
+    """Authenticate with NASA Earthdata using non-interactive strategies.
+
+    Raises:
+        RuntimeError: If authentication fails (credentials not configured).
+    """
+    import earthaccess
+
+    auth = earthaccess.login(strategy="environment")
+    if not auth:
+        auth = earthaccess.login(strategy="netrc")
+    if not auth:
+        raise RuntimeError(
+            "NASA Earthdata authentication failed.\n\n"
+            "Please configure your credentials in the Settings tab "
+            "(Plugins > NASA OPERA > Settings) or set the "
+            "EARTHDATA_USERNAME and EARTHDATA_PASSWORD environment variables."
+        )
+
+
 class SearchWorker(QThread):
     """Worker thread for searching NASA OPERA data."""
 
@@ -136,7 +156,7 @@ class SearchWorker(QThread):
             import earthaccess
 
             # Authenticate
-            earthaccess.login(persist=True)
+            _earthdata_login()
 
             self.progress.emit(f"Searching for {self.short_name}...")
 
@@ -276,7 +296,7 @@ class DownloadRasterWorker(QThread):
             import earthaccess
 
             self.progress.emit("Authenticating with NASA Earthdata...")
-            earthaccess.login(persist=True)
+            _earthdata_login()
 
             self.progress.emit(f"Downloading {self.layer_name}...")
 
@@ -364,7 +384,7 @@ class DownloadGranulesWorker(QThread):
             import earthaccess
 
             self.progress.emit("Authenticating with NASA Earthdata...")
-            earthaccess.login(persist=True)
+            _earthdata_login()
 
             os.makedirs(self.download_dir, exist_ok=True)
 
@@ -462,7 +482,7 @@ def setup_gdal_for_earthdata():
         from osgeo import gdal
 
         # Authenticate and get S3 credentials
-        earthaccess.login(persist=True)
+        _earthdata_login()
         s3_credentials = earthaccess.get_s3_credentials(daac="PODAAC")
 
         # Configure GDAL for S3 access

--- a/nasa_opera/metadata.txt
+++ b/nasa_opera/metadata.txt
@@ -2,7 +2,7 @@
 name=NASA OPERA
 qgisMinimumVersion=3.28
 description=Search and visualize NASA OPERA (Observational Products for End-Users from Remote Sensing Analysis) satellite data products.
-version=0.4.0
+version=0.4.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -46,6 +46,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.4.1
+        - Fix cryptic 'lost sys.stdin' error (#15)
     0.4.0
         - Add one-click dependency installer (#13)
     0.3.0


### PR DESCRIPTION
## Summary
- Replace `earthaccess.login(persist=True)` with a non-interactive `_earthdata_login()` helper that uses explicit strategies (`environment`, then `netrc`)
- When authentication fails, raises a clear error guiding users to configure credentials in the Settings tab instead of the cryptic `lost sys.stdin` message
- Applies the same pattern already used in `settings_dock.py` to all four login call sites in `opera_dock.py`

## Test plan
- [ ] Open QGIS with plugin loaded, **without** credentials configured — click Search and verify the error message reads: "NASA Earthdata authentication failed. Please configure your credentials in the Settings tab..."
- [ ] Configure credentials in Settings tab, then verify Search, single-file download, and bulk download all authenticate successfully