### PR TITLE
Use uv for faster dependency installation

### DIFF
--- a/nasa_opera/deps_manager.py
+++ b/nasa_opera/deps_manager.py
@@ -14,6 +14,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import time
 from typing import Callable, Dict, List, Optional, Tuple
 
 from qgis.PyQt.QtCore import QThread, pyqtSignal
@@ -378,11 +379,14 @@ def _verify_pip_and_return(python_path: str) -> str:
 def create_venv(venv_dir: str) -> str:
     """Create a virtual environment at the specified path.
 
-    Uses a multi-strategy approach to handle embedded Python environments
-    (e.g. QGIS on Windows) where ``sys.executable`` may point to
-    ``qgis-bin.exe`` rather than ``python.exe``.
+    When uv is available, uses ``uv venv`` which is faster and does not
+    require pip to be bootstrapped inside the venv.
 
-    Strategy order:
+    Otherwise uses a multi-strategy approach to handle embedded Python
+    environments (e.g. QGIS on Windows) where ``sys.executable`` may point
+    to ``qgis-bin.exe`` rather than ``python.exe``.
+
+    Pip fallback strategy order:
         1. Subprocess using the real Python executable found by
            ``_find_python_executable()`` (primary, works on Windows QGIS).
         2. In-process ``venv.EnvBuilder`` (fallback, only when
@@ -399,14 +403,34 @@ def create_venv(venv_dir: str) -> str:
     Raises:
         RuntimeError: If venv creation fails after all strategies.
     """
+    from .uv_manager import get_uv_path, uv_exists
+
     os.makedirs(os.path.dirname(venv_dir), exist_ok=True)
 
     python_path = get_venv_python_path(venv_dir)
+    env = _get_clean_env()
+    kwargs = _get_subprocess_kwargs()
+
+    # Strategy 0: Use uv venv when available (fastest, no pip needed)
+    if uv_exists():
+        uv_path = get_uv_path()
+        python_exe = _find_python_executable()
+        cmd = [uv_path, "venv", "--python", python_exe, venv_dir]
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+            **kwargs,
+        )
+        if result.returncode == 0 and os.path.isfile(python_path):
+            return python_path
+        # uv venv failed — clean up and fall through to pip strategies
+        _cleanup_partial_venv(venv_dir)
 
     # Strategy 1: Subprocess with the real Python executable
     python_exe = _find_python_executable()
-    env = _get_clean_env()
-    kwargs = _get_subprocess_kwargs()
     subprocess_error = ""
 
     cmd = [python_exe, "-m", "venv", venv_dir]
@@ -480,6 +504,9 @@ def install_packages(
 ) -> Tuple[bool, str]:
     """Install packages into the virtual environment.
 
+    Uses uv when available for significantly faster installation,
+    falling back to pip otherwise.
+
     Args:
         venv_dir: Path to the venv directory.
         packages: List of pip package names to install.
@@ -488,22 +515,37 @@ def install_packages(
     Returns:
         Tuple of (success, message).
     """
+    from .uv_manager import get_uv_path, uv_exists
+
     python_path = get_venv_python_path(venv_dir)
     env = _get_clean_env()
     kwargs = _get_subprocess_kwargs()
 
-    cmd = [
-        python_path,
-        "-m",
-        "pip",
-        "install",
-        "--upgrade",
-        "--disable-pip-version-check",
-        "--prefer-binary",
-    ] + packages
+    use_uv = uv_exists()
+    if use_uv:
+        uv_path = get_uv_path()
+        cmd = [
+            uv_path,
+            "pip",
+            "install",
+            "--python",
+            python_path,
+            "--upgrade",
+        ] + packages
+    else:
+        cmd = [
+            python_path,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "--disable-pip-version-check",
+            "--prefer-binary",
+        ] + packages
 
     if progress_callback:
-        progress_callback(20, f"Installing: {', '.join(packages)}...")
+        installer = "uv" if use_uv else "pip"
+        progress_callback(20, f"Installing ({installer}): {', '.join(packages)}...")
 
     result = subprocess.run(
         cmd,
@@ -519,7 +561,8 @@ def install_packages(
         # Truncate long error messages
         if len(error_output) > 1000:
             error_output = "..." + error_output[-1000:]
-        return False, f"pip install failed:\n{error_output}"
+        installer = "uv pip" if use_uv else "pip"
+        return False, f"{installer} install failed:\n{error_output}"
 
     return True, "Packages installed successfully."
 
@@ -531,9 +574,26 @@ class DepsInstallWorker(QThread):
     finished = pyqtSignal(bool, str)
 
     def run(self):
-        """Execute venv creation and dependency installation."""
+        """Execute uv download, venv creation, and dependency installation."""
         try:
+            from .uv_manager import download_uv, uv_exists
+
+            start_time = time.time()
             venv_dir = get_venv_dir()
+
+            # Step 0: Download uv if needed (fast package installer)
+            if not uv_exists():
+                self.progress.emit(2, "Downloading uv package installer...")
+                success, msg = download_uv(
+                    progress_callback=lambda p, m: self.progress.emit(
+                        2 + int(p * 0.03), m
+                    ),
+                )
+                if not success:
+                    # Non-fatal: fall back to pip
+                    self.progress.emit(5, "uv unavailable, using pip instead.")
+                else:
+                    self.progress.emit(5, "uv ready.")
 
             # Step 1: Create venv if needed
             if not venv_exists():
@@ -545,29 +605,31 @@ class DepsInstallWorker(QThread):
                     return
             self.progress.emit(10, "Virtual environment ready.")
 
-            # Step 2: Verify pip
-            self.progress.emit(12, "Verifying pip...")
-            python_path = get_venv_python_path(venv_dir)
-            env = _get_clean_env()
-            kwargs = _get_subprocess_kwargs()
+            # Step 2: Verify pip (only needed when not using uv)
+            use_uv = uv_exists()
+            if not use_uv:
+                self.progress.emit(12, "Verifying pip...")
+                python_path = get_venv_python_path(venv_dir)
+                env = _get_clean_env()
+                kwargs = _get_subprocess_kwargs()
 
-            result = subprocess.run(
-                [python_path, "-m", "pip", "--version"],
-                capture_output=True,
-                text=True,
-                timeout=30,
-                env=env,
-                **kwargs,
-            )
-            if result.returncode != 0:
-                self.finished.emit(
-                    False,
-                    "pip is not available in the virtual environment.\n"
-                    "Please install dependencies manually:\n"
-                    "pip install earthaccess geopandas shapely pandas",
+                result = subprocess.run(
+                    [python_path, "-m", "pip", "--version"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    env=env,
+                    **kwargs,
                 )
-                return
-            self.progress.emit(15, "pip is available.")
+                if result.returncode != 0:
+                    self.finished.emit(
+                        False,
+                        "pip is not available in the virtual environment.\n"
+                        "Please install dependencies manually:\n"
+                        "pip install earthaccess geopandas shapely pandas",
+                    )
+                    return
+            self.progress.emit(15, "Package installer ready.")
 
             # Step 3: Install missing packages
             missing = get_missing_packages()
@@ -595,6 +657,14 @@ class DepsInstallWorker(QThread):
             # Step 5: Verify imports
             self.progress.emit(95, "Verifying installations...")
             still_missing = get_missing_packages()
+
+            elapsed = time.time() - start_time
+            if elapsed >= 60:
+                minutes, seconds = divmod(int(round(elapsed)), 60)
+                elapsed_str = f"{minutes}:{seconds:02d}"
+            else:
+                elapsed_str = f"{elapsed:.1f}s"
+
             if still_missing:
                 self.finished.emit(
                     False,
@@ -603,8 +673,11 @@ class DepsInstallWorker(QThread):
                     "You may need to restart QGIS for changes to take effect.",
                 )
             else:
-                self.progress.emit(100, "All dependencies installed!")
-                self.finished.emit(True, "All dependencies installed successfully!")
+                self.progress.emit(100, f"All dependencies installed in {elapsed_str}!")
+                self.finished.emit(
+                    True,
+                    f"All dependencies installed successfully in {elapsed_str}!",
+                )
 
         except subprocess.TimeoutExpired:
             self.finished.emit(False, "Installation timed out after 10 minutes.")

--- a/nasa_opera/uv_manager.py
+++ b/nasa_opera/uv_manager.py
@@ -25,7 +25,9 @@ from qgis.PyQt.QtNetwork import QNetworkRequest
 CACHE_DIR = os.path.join(os.path.expanduser("~"), ".qgis_nasa_opera")
 UV_DIR = os.path.join(CACHE_DIR, "uv")
 
-# Pin a known-good uv version
+# Pin a known-good uv version.
+# Verified platforms: x86_64-pc-windows-msvc, x86_64-apple-darwin,
+# aarch64-apple-darwin, x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu.
 UV_VERSION = "0.10.6"
 
 
@@ -89,8 +91,7 @@ def get_uv_download_url() -> str:
     platform_str, ext = _get_uv_platform_info()
     filename = f"uv-{platform_str}{ext}"
     return (
-        f"https://github.com/astral-sh/uv/releases/download/"
-        f"{UV_VERSION}/{filename}"
+        f"https://github.com/astral-sh/uv/releases/download/" f"{UV_VERSION}/{filename}"
     )
 
 
@@ -106,9 +107,7 @@ def _safe_extract_tar(tar, dest_dir):
     for member in tar.getmembers():
         member_path = os.path.realpath(os.path.join(dest_dir, member.name))
         if not member_path.startswith(dest_dir + os.sep) and member_path != dest_dir:
-            raise ValueError(
-                f"Attempted path traversal in tar archive: {member.name}"
-            )
+            raise ValueError(f"Attempted path traversal in tar archive: {member.name}")
         if use_filter:
             tar.extract(member, dest_dir, filter="data")
         else:
@@ -126,9 +125,7 @@ def _safe_extract_zip(zip_file, dest_dir):
     for member in zip_file.namelist():
         member_path = os.path.realpath(os.path.join(dest_dir, member))
         if not member_path.startswith(dest_dir + os.sep) and member_path != dest_dir:
-            raise ValueError(
-                f"Attempted path traversal in zip archive: {member}"
-            )
+            raise ValueError(f"Attempted path traversal in zip archive: {member}")
         zip_file.extract(member, dest_dir)
 
 
@@ -193,8 +190,7 @@ def download_uv(
             error_msg = request.errorMessage()
             if "404" in error_msg or "Not Found" in error_msg:
                 error_msg = (
-                    f"uv {UV_VERSION} not available for this platform. "
-                    f"URL: {url}"
+                    f"uv {UV_VERSION} not available for this platform. " f"URL: {url}"
                 )
             else:
                 error_msg = f"Download failed: {error_msg}"
@@ -238,7 +234,17 @@ def download_uv(
             uv_binary = _find_file_in_dir(extract_dir, uv_binary_name)
 
             if uv_binary is None:
-                return False, "uv binary not found in archive"
+                found_files = []
+                for root, _dirs, files in os.walk(extract_dir):
+                    found_files.extend(files)
+                    if len(found_files) >= 20:
+                        break
+                files_str = ", ".join(found_files[:20])
+                return False, (
+                    f"uv binary not found in archive. "
+                    f"Expected '{uv_binary_name}'. "
+                    f"Files found (up to 20): {files_str}"
+                )
 
             dest = get_uv_path()
             shutil.copy2(uv_binary, dest)
@@ -265,7 +271,7 @@ def download_uv(
         if success:
             if progress_callback:
                 progress_callback(100, f"uv {UV_VERSION} installed")
-            _log("uv installed successfully", Qgis.Success)
+            _log("uv installed successfully")
             return True, f"uv {UV_VERSION} installed successfully"
         else:
             return False, f"Verification failed: {verify_msg}"
@@ -318,7 +324,7 @@ def verify_uv() -> Tuple[bool, str]:
 
         if result.returncode == 0:
             version_output = result.stdout.strip()
-            _log(f"Verified uv: {version_output}", Qgis.Success)
+            _log(f"Verified uv: {version_output}")
             return True, version_output
         else:
             error = result.stderr or "Unknown error"
@@ -342,7 +348,7 @@ def remove_uv() -> Tuple[bool, str]:
 
     try:
         shutil.rmtree(UV_DIR)
-        _log("Removed uv installation", Qgis.Success)
+        _log("Removed uv installation")
         return True, "uv removed"
     except Exception as e:
         error_msg = f"Failed to remove uv: {str(e)}"

--- a/nasa_opera/uv_manager.py
+++ b/nasa_opera/uv_manager.py
@@ -1,0 +1,350 @@
+"""
+UV Package Installer Manager for NASA OPERA Plugin.
+
+Downloads and manages the uv package installer binary for fast
+dependency installation in the plugin's virtual environment.
+
+Source: https://github.com/astral-sh/uv
+"""
+
+import os
+import sys
+import platform
+import stat
+import subprocess
+import tarfile
+import zipfile
+import tempfile
+import shutil
+from typing import Callable, Optional, Tuple
+
+from qgis.core import QgsMessageLog, Qgis, QgsBlockingNetworkRequest
+from qgis.PyQt.QtCore import QUrl
+from qgis.PyQt.QtNetwork import QNetworkRequest
+
+CACHE_DIR = os.path.join(os.path.expanduser("~"), ".qgis_nasa_opera")
+UV_DIR = os.path.join(CACHE_DIR, "uv")
+
+# Pin a known-good uv version
+UV_VERSION = "0.10.6"
+
+
+def _log(message, level=Qgis.Info):
+    """Log a message to the QGIS message log.
+
+    Args:
+        message: The message to log.
+        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+    """
+    QgsMessageLog.logMessage(str(message), "NASA OPERA", level=level)
+
+
+def get_uv_path() -> str:
+    """Get the path to the uv binary.
+
+    Returns:
+        The absolute path to the uv executable.
+    """
+    if sys.platform == "win32":
+        return os.path.join(UV_DIR, "uv.exe")
+    return os.path.join(UV_DIR, "uv")
+
+
+def uv_exists() -> bool:
+    """Check if the uv binary is already installed.
+
+    Returns:
+        True if the uv executable exists.
+    """
+    return os.path.exists(get_uv_path())
+
+
+def _get_uv_platform_info() -> Tuple[str, str]:
+    """Get platform and architecture info for the uv download URL.
+
+    Returns:
+        A tuple of (platform_string, file_extension).
+    """
+    system = sys.platform
+    machine = platform.machine().lower()
+
+    if system == "darwin":
+        if machine in ("arm64", "aarch64"):
+            return ("aarch64-apple-darwin", ".tar.gz")
+        return ("x86_64-apple-darwin", ".tar.gz")
+    elif system == "win32":
+        return ("x86_64-pc-windows-msvc", ".zip")
+    else:
+        if machine in ("arm64", "aarch64"):
+            return ("aarch64-unknown-linux-gnu", ".tar.gz")
+        return ("x86_64-unknown-linux-gnu", ".tar.gz")
+
+
+def get_uv_download_url() -> str:
+    """Construct the download URL for the uv binary.
+
+    Returns:
+        The full download URL string.
+    """
+    platform_str, ext = _get_uv_platform_info()
+    filename = f"uv-{platform_str}{ext}"
+    return (
+        f"https://github.com/astral-sh/uv/releases/download/"
+        f"{UV_VERSION}/{filename}"
+    )
+
+
+def _safe_extract_tar(tar, dest_dir):
+    """Safely extract tar archive with path traversal protection.
+
+    Args:
+        tar: An open tarfile.TarFile object.
+        dest_dir: Destination directory for extraction.
+    """
+    dest_dir = os.path.realpath(dest_dir)
+    use_filter = sys.version_info >= (3, 12)
+    for member in tar.getmembers():
+        member_path = os.path.realpath(os.path.join(dest_dir, member.name))
+        if not member_path.startswith(dest_dir + os.sep) and member_path != dest_dir:
+            raise ValueError(
+                f"Attempted path traversal in tar archive: {member.name}"
+            )
+        if use_filter:
+            tar.extract(member, dest_dir, filter="data")
+        else:
+            tar.extract(member, dest_dir)
+
+
+def _safe_extract_zip(zip_file, dest_dir):
+    """Safely extract zip archive with path traversal protection.
+
+    Args:
+        zip_file: An open zipfile.ZipFile object.
+        dest_dir: Destination directory for extraction.
+    """
+    dest_dir = os.path.realpath(dest_dir)
+    for member in zip_file.namelist():
+        member_path = os.path.realpath(os.path.join(dest_dir, member))
+        if not member_path.startswith(dest_dir + os.sep) and member_path != dest_dir:
+            raise ValueError(
+                f"Attempted path traversal in zip archive: {member}"
+            )
+        zip_file.extract(member, dest_dir)
+
+
+def _find_file_in_dir(directory, filename):
+    """Find a file by name within a directory tree.
+
+    Args:
+        directory: The root directory to search.
+        filename: The filename to find.
+
+    Returns:
+        The full path to the file, or None if not found.
+    """
+    for root, _dirs, files in os.walk(directory):
+        if filename in files:
+            return os.path.join(root, filename)
+    return None
+
+
+def download_uv(
+    progress_callback: Optional[Callable[[int, str], None]] = None,
+    cancel_check: Optional[Callable[[], bool]] = None,
+) -> Tuple[bool, str]:
+    """Download and install the uv binary using QGIS network manager.
+
+    Uses QgsBlockingNetworkRequest to respect QGIS proxy settings.
+
+    Args:
+        progress_callback: Function called with (percent, message) for progress.
+        cancel_check: Function that returns True if operation should be cancelled.
+
+    Returns:
+        A tuple of (success: bool, message: str).
+    """
+    if uv_exists():
+        _log("uv already exists")
+        return True, "uv already installed"
+
+    url = get_uv_download_url()
+    _log(f"Downloading uv {UV_VERSION} from: {url}")
+
+    if progress_callback:
+        progress_callback(0, f"Downloading uv {UV_VERSION}...")
+
+    _, ext = _get_uv_platform_info()
+    fd, temp_path = tempfile.mkstemp(suffix=ext)
+    os.close(fd)
+
+    try:
+        if cancel_check and cancel_check():
+            return False, "Download cancelled"
+
+        request = QgsBlockingNetworkRequest()
+        qurl = QUrl(url)
+
+        if progress_callback:
+            progress_callback(5, "Connecting to download server...")
+
+        err = request.get(QNetworkRequest(qurl))
+
+        if err != QgsBlockingNetworkRequest.NoError:
+            error_msg = request.errorMessage()
+            if "404" in error_msg or "Not Found" in error_msg:
+                error_msg = (
+                    f"uv {UV_VERSION} not available for this platform. "
+                    f"URL: {url}"
+                )
+            else:
+                error_msg = f"Download failed: {error_msg}"
+            _log(error_msg, Qgis.Critical)
+            return False, error_msg
+
+        if cancel_check and cancel_check():
+            return False, "Download cancelled"
+
+        reply = request.reply()
+        content = reply.content()
+
+        if progress_callback:
+            total_mb = len(content) / (1024 * 1024)
+            progress_callback(50, f"Downloaded {total_mb:.1f} MB, saving...")
+
+        with open(temp_path, "wb") as f:
+            f.write(content.data())
+
+        _log(f"Download complete ({len(content)} bytes), extracting...")
+
+        if progress_callback:
+            progress_callback(60, "Extracting uv...")
+
+        if os.path.exists(UV_DIR):
+            shutil.rmtree(UV_DIR)
+        os.makedirs(UV_DIR, exist_ok=True)
+
+        # Extract archive to a temporary directory, then move the binary
+        extract_dir = tempfile.mkdtemp()
+        try:
+            if temp_path.endswith(".zip"):
+                with zipfile.ZipFile(temp_path, "r") as z:
+                    _safe_extract_zip(z, extract_dir)
+            else:
+                with tarfile.open(temp_path, "r:gz") as tar:
+                    _safe_extract_tar(tar, extract_dir)
+
+            # Find the uv binary in the extracted contents
+            uv_binary_name = "uv.exe" if sys.platform == "win32" else "uv"
+            uv_binary = _find_file_in_dir(extract_dir, uv_binary_name)
+
+            if uv_binary is None:
+                return False, "uv binary not found in archive"
+
+            dest = get_uv_path()
+            shutil.copy2(uv_binary, dest)
+
+            # Set executable permissions on Unix
+            if sys.platform != "win32":
+                os.chmod(
+                    dest,
+                    stat.S_IRWXU
+                    | stat.S_IRGRP
+                    | stat.S_IXGRP
+                    | stat.S_IROTH
+                    | stat.S_IXOTH,
+                )
+
+        finally:
+            shutil.rmtree(extract_dir, ignore_errors=True)
+
+        if progress_callback:
+            progress_callback(80, "Verifying uv installation...")
+
+        success, verify_msg = verify_uv()
+
+        if success:
+            if progress_callback:
+                progress_callback(100, f"uv {UV_VERSION} installed")
+            _log("uv installed successfully", Qgis.Success)
+            return True, f"uv {UV_VERSION} installed successfully"
+        else:
+            return False, f"Verification failed: {verify_msg}"
+
+    except InterruptedError:
+        return False, "Download cancelled"
+    except Exception as e:
+        error_msg = f"uv installation failed: {str(e)}"
+        _log(error_msg, Qgis.Critical)
+        return False, error_msg
+    finally:
+        if os.path.exists(temp_path):
+            try:
+                os.remove(temp_path)
+            except OSError:
+                pass
+
+
+def verify_uv() -> Tuple[bool, str]:
+    """Verify that the uv binary works.
+
+    Returns:
+        A tuple of (success: bool, message: str).
+    """
+    uv_path = get_uv_path()
+
+    if not os.path.exists(uv_path):
+        return False, f"uv not found at {uv_path}"
+
+    try:
+        env = os.environ.copy()
+        env.pop("PYTHONPATH", None)
+        env.pop("PYTHONHOME", None)
+
+        kwargs = {}
+        if sys.platform == "win32":
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            startupinfo.wShowWindow = subprocess.SW_HIDE
+            kwargs["startupinfo"] = startupinfo
+
+        result = subprocess.run(
+            [uv_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+            **kwargs,
+        )
+
+        if result.returncode == 0:
+            version_output = result.stdout.strip()
+            _log(f"Verified uv: {version_output}", Qgis.Success)
+            return True, version_output
+        else:
+            error = result.stderr or "Unknown error"
+            _log(f"uv verification failed: {error}", Qgis.Warning)
+            return False, f"Verification failed: {error[:100]}"
+
+    except subprocess.TimeoutExpired:
+        return False, "uv verification timed out"
+    except Exception as e:
+        return False, f"Verification error: {str(e)[:100]}"
+
+
+def remove_uv() -> Tuple[bool, str]:
+    """Remove the uv installation.
+
+    Returns:
+        A tuple of (success: bool, message: str).
+    """
+    if not os.path.exists(UV_DIR):
+        return True, "uv not installed"
+
+    try:
+        shutil.rmtree(UV_DIR)
+        _log("Removed uv installation", Qgis.Success)
+        return True, "uv removed"
+    except Exception as e:
+        error_msg = f"Failed to remove uv: {str(e)}"
+        _log(error_msg, Qgis.Warning)
+        return False, error_msg


### PR DESCRIPTION
## Summary
- Add `uv_manager.py` to download and manage the [uv](https://github.com/astral-sh/uv) binary from Astral's GitHub releases
- Use `uv venv` and `uv pip install` instead of `python -m venv` + `python -m pip install` for significantly faster dependency installation (10-100x speedup)
- Gracefully fall back to pip if uv cannot be downloaded (e.g., corporate firewalls), keeping all existing pip code intact
- Show total installation time on completion (e.g., "42.3s" or "2:05" for longer installs)

## Test plan
- [ ] Delete `~/.qgis_nasa_opera/` and click "Install Dependencies" — should download uv, create venv with uv, install packages with uv
- [ ] Delete just `~/.qgis_nasa_opera/uv/` and install — should fall back to pip gracefully
- [ ] Re-click "Install Dependencies" when everything exists — should skip downloads and detect packages
- [ ] Check QGIS log messages for uv-related entries confirming uv was used
- [ ] Verify OPERA search panel works after installation
- [ ] Test on Windows, macOS, and Linux