### PR TITLE
Add Qt5/Qt6 dual compatibility for QGIS 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+    push:
+        branches: ["**"]
+    pull_request:
+        branches: [main]
+
+jobs:
+    pre-commit:
+        name: pre-commit
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+            - uses: pre-commit/action@v3.0.1
+
+    bandit:
+        name: Bandit security scan
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+            - name: Install Bandit
+              run: pip install bandit
+            - name: Run Bandit (matches plugins.qgis.org security scan)
+              run: bandit -r nasa_opera
+
+    pyqt6-smoke:
+        name: PyQt6 import smoke
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ["3.10", "3.11", "3.12", "3.13"]
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install Qt6 runtime libs
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+            - name: Install PyQt6 and pytest
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install PyQt6 pytest
+            - name: Run import smoke tests
+              run: pytest tests -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,10 @@ repos:
       rev: 0.9.1
       hooks:
           - id: nbstripout
+
+    - repo: https://github.com/PyCQA/bandit
+      rev: 1.9.4
+      hooks:
+          - id: bandit
+            args: ["-r", "nasa_opera"]
+            pass_filenames: false

--- a/nasa_opera/ai/oauth.py
+++ b/nasa_opera/ai/oauth.py
@@ -24,17 +24,30 @@ from qgis.PyQt.QtGui import QDesktopServices
 OAUTH_CONFIG = {
     "anthropic": {
         "auth_url": "https://console.anthropic.com/oauth/authorize",
-        "token_url": "https://console.anthropic.com/oauth/token",
+        "token_url": "https://console.anthropic.com/oauth/token",  # nosec B105
         "client_id": "",
         "scope": "api",
     },
     "openai": {
         "auth_url": "https://platform.openai.com/oauth/authorize",
-        "token_url": "https://platform.openai.com/oauth/token",
+        "token_url": "https://platform.openai.com/oauth/token",  # nosec B105
         "client_id": "",
         "scope": "api",
     },
 }
+
+
+def _require_https(url: str) -> None:
+    """Reject any URL that does not use the https scheme.
+
+    Args:
+        url: URL string to validate.
+
+    Raises:
+        ValueError: If the URL is not https.
+    """
+    if not url.lower().startswith("https://"):
+        raise ValueError(f"Refusing non-https URL: {url!r}")
 
 
 def _generate_pkce_pair() -> Tuple[str, str]:
@@ -224,6 +237,7 @@ class OAuthFlow:
             }
         ).encode("utf-8")
 
+        _require_https(config["token_url"])
         req = urllib.request.Request(
             config["token_url"],
             data=data,
@@ -231,7 +245,7 @@ class OAuthFlow:
         )
 
         try:
-            with urllib.request.urlopen(req, timeout=30) as response:
+            with urllib.request.urlopen(req, timeout=30) as response:  # nosec B310
                 token_data = json.loads(response.read().decode("utf-8"))
         except Exception as e:
             return False, f"Token exchange failed: {e}"

--- a/nasa_opera/deps_manager.py
+++ b/nasa_opera/deps_manager.py
@@ -12,7 +12,7 @@ import importlib
 import os
 import platform
 import shutil
-import subprocess
+import subprocess  # nosec B404
 import sys
 import time
 from typing import Callable, Dict, List, Optional, Tuple
@@ -394,8 +394,9 @@ def _verify_pip_and_return(python_path: str) -> str:
     env = _get_clean_env()
     kwargs = _get_subprocess_kwargs()
 
-    # Try ensurepip (may already be present from EnvBuilder)
-    subprocess.run(
+    # Try ensurepip (may already be present from EnvBuilder).
+    # python_path resolved by us; argv is a fixed list; shell=False (default).
+    subprocess.run(  # nosec B603
         [python_path, "-m", "ensurepip", "--upgrade"],
         capture_output=True,
         text=True,
@@ -405,7 +406,7 @@ def _verify_pip_and_return(python_path: str) -> str:
     )
 
     # Verify pip works
-    result = subprocess.run(
+    result = subprocess.run(  # nosec B603
         [python_path, "-m", "pip", "--version"],
         capture_output=True,
         text=True,
@@ -463,7 +464,7 @@ def create_venv(venv_dir: str) -> str:
         uv_path = get_uv_path()
         python_exe = _find_python_executable()
         cmd = [uv_path, "venv", "--python", python_exe, venv_dir]
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             cmd,
             capture_output=True,
             text=True,
@@ -481,7 +482,7 @@ def create_venv(venv_dir: str) -> str:
     subprocess_error = ""
 
     cmd = [python_exe, "-m", "venv", venv_dir]
-    result = subprocess.run(
+    result = subprocess.run(  # nosec B603
         cmd,
         capture_output=True,
         text=True,
@@ -507,7 +508,7 @@ def create_venv(venv_dir: str) -> str:
 
     # Strategy 3: Create venv without pip, then copy Python executable if needed
     try:
-        result2 = subprocess.run(
+        result2 = subprocess.run(  # nosec B603
             [python_exe, "-m", "venv", "--without-pip", venv_dir],
             capture_output=True,
             text=True,
@@ -520,8 +521,8 @@ def create_venv(venv_dir: str) -> str:
                 _try_copy_python_executable(venv_dir)
             if os.path.isfile(python_path):
                 return _verify_pip_and_return(python_path)
-    except Exception:
-        pass
+    except Exception as exc:
+        print(f"NASA OPERA: venv strategy 3 failed: {exc}", file=sys.stderr)
 
     # All strategies failed
     details = [
@@ -594,7 +595,8 @@ def install_packages(
         installer = "uv" if use_uv else "pip"
         progress_callback(20, f"Installing ({installer}): {', '.join(packages)}...")
 
-    result = subprocess.run(
+    # cmd is built from controlled paths and an internal package list.
+    result = subprocess.run(  # nosec B603
         cmd,
         capture_output=True,
         text=True,
@@ -660,7 +662,7 @@ class DepsInstallWorker(QThread):
                 env = _get_clean_env()
                 kwargs = _get_subprocess_kwargs()
 
-                result = subprocess.run(
+                result = subprocess.run(  # nosec B603
                     [python_path, "-m", "pip", "--version"],
                     capture_output=True,
                     text=True,

--- a/nasa_opera/dialogs/ai_chat_dock.py
+++ b/nasa_opera/dialogs/ai_chat_dock.py
@@ -40,7 +40,7 @@ def _is_dark_theme() -> bool:
         True if the application uses a dark theme.
     """
     palette = QApplication.instance().palette()
-    bg = palette.color(QPalette.Window)
+    bg = palette.color(QPalette.ColorRole.Window)
     # A window background with lightness below 128 is considered dark
     return bg.lightness() < 128
 
@@ -139,8 +139,8 @@ class ChatInputWidget(QPlainTextEdit):
         Args:
             event: The key event.
         """
-        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
-            if event.modifiers() & Qt.ShiftModifier:
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+            if event.modifiers() & Qt.KeyboardModifier.ShiftModifier:
                 super().keyPressEvent(event)
             else:
                 self._send_callback()
@@ -167,7 +167,9 @@ class AIChatDockWidget(QDockWidget):
         self._agent = None
         self._tool_registry = None
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
         self._colors = _theme_colors()
         self._setup_ui()
 

--- a/nasa_opera/dialogs/opera_dock.py
+++ b/nasa_opera/dialogs/opera_dock.py
@@ -11,6 +11,7 @@ This module provides the main NASA OPERA search interface that allows users to:
 import os
 import json
 import math
+import sys
 import tempfile
 from datetime import datetime, date
 from typing import Optional, List, Tuple
@@ -120,7 +121,11 @@ def _earthdata_login():
             auth = earthaccess.login(strategy=strategy)
             if auth:
                 return
-        except Exception:
+        except Exception as exc:
+            print(
+                f"NASA OPERA: earthaccess login via {strategy} failed: {exc}",
+                file=sys.stderr,
+            )
             continue
 
     raise RuntimeError(
@@ -567,7 +572,9 @@ class RectangleMapTool(QgsMapToolEmitPoint):
         # Create rubber band for visual feedback
         if self.rubber_band is not None:
             self.canvas.scene().removeItem(self.rubber_band)
-        self.rubber_band = QgsRubberBand(self.canvas, QgsWkbTypes.PolygonGeometry)
+        self.rubber_band = QgsRubberBand(
+            self.canvas, QgsWkbTypes.GeometryType.PolygonGeometry
+        )
         self.rubber_band.setColor(QColor(255, 0, 0, 100))
         self.rubber_band.setWidth(2)
         self._update_rubber_band()
@@ -610,7 +617,7 @@ class RectangleMapTool(QgsMapToolEmitPoint):
         """Update the rubber band rectangle display."""
         if self.rubber_band is None:
             return
-        self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+        self.rubber_band.reset(QgsWkbTypes.GeometryType.PolygonGeometry)
         rect = QgsRectangle(self.start_point, self.end_point)
         rect.normalize()
         self.rubber_band.addPoint(QgsPointXY(rect.xMinimum(), rect.yMinimum()), False)
@@ -653,7 +660,9 @@ class OperaDockWidget(QDockWidget):
         # Selection sync guard flag
         self._sync_in_progress = False
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         self._setup_ui()
 
@@ -674,7 +683,7 @@ class OperaDockWidget(QDockWidget):
         header_font.setPointSize(11)
         header_font.setBold(True)
         header_label.setFont(header_font)
-        header_label.setAlignment(Qt.AlignCenter)
+        header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         header_label.setStyleSheet("color: #64B5F6; padding: 5px;")
         layout.addWidget(header_label)
 
@@ -804,19 +813,23 @@ class OperaDockWidget(QDockWidget):
 
         self.granule_table = QTableWidget()
         self.granule_table.setEnabled(False)
-        self.granule_table.setSelectionMode(QAbstractItemView.ExtendedSelection)
-        self.granule_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.granule_table.setSelectionMode(
+            QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        self.granule_table.setSelectionBehavior(
+            QAbstractItemView.SelectionBehavior.SelectRows
+        )
         self.granule_table.setColumnCount(4)
         self.granule_table.setHorizontalHeaderLabels(
             ["Granule ID", "Begin Date", "End Date", "Links"]
         )
         self.granule_table.horizontalHeader().setSectionResizeMode(
-            QHeaderView.Interactive
+            QHeaderView.ResizeMode.Interactive
         )
         self.granule_table.horizontalHeader().setStretchLastSection(True)
         self.granule_table.setSortingEnabled(True)
         self.granule_table.setMinimumHeight(120)
-        self.granule_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.granule_table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.granule_table.itemSelectionChanged.connect(
             self._on_granule_selection_changed
         )
@@ -1071,7 +1084,7 @@ class OperaDockWidget(QDockWidget):
 
             native_id = result.get("meta", {}).get("native-id", f"Granule {i + 1}")
             id_item = QTableWidgetItem(native_id)
-            id_item.setData(Qt.UserRole, i)  # Store granule index
+            id_item.setData(Qt.ItemDataRole.UserRole, i)  # Store granule index
             id_item.setToolTip(native_id)
             self.granule_table.setItem(row, 0, id_item)
 
@@ -1097,7 +1110,7 @@ class OperaDockWidget(QDockWidget):
             self.granule_table.setItem(row, 2, QTableWidgetItem(end_date))
 
             links_item = QTableWidgetItem()
-            links_item.setData(Qt.DisplayRole, num_links)  # Numeric sort
+            links_item.setData(Qt.ItemDataRole.DisplayRole, num_links)  # Numeric sort
             self.granule_table.setItem(row, 3, links_item)
 
         self.granule_table.setSortingEnabled(True)  # Re-enable sorting
@@ -1153,7 +1166,7 @@ class OperaDockWidget(QDockWidget):
         item = self.granule_table.item(first_row, 0)
         if item is None:
             return
-        index = item.data(Qt.UserRole)
+        index = item.data(Qt.ItemDataRole.UserRole)
 
         if index is None or index >= len(self._results):
             return
@@ -1199,7 +1212,7 @@ class OperaDockWidget(QDockWidget):
             for row in selected_rows:
                 item = self.granule_table.item(row, 0)
                 if item is not None:
-                    granule_index = item.data(Qt.UserRole)
+                    granule_index = item.data(Qt.ItemDataRole.UserRole)
                     if granule_index is not None:
                         feature_ids.append(granule_index)
 
@@ -1231,7 +1244,7 @@ class OperaDockWidget(QDockWidget):
             for row in range(self.granule_table.rowCount()):
                 item = self.granule_table.item(row, 0)
                 if item is not None:
-                    granule_index = item.data(Qt.UserRole)
+                    granule_index = item.data(Qt.ItemDataRole.UserRole)
                     if granule_index is not None:
                         index_to_row[granule_index] = row
 
@@ -1274,7 +1287,9 @@ class OperaDockWidget(QDockWidget):
             return
 
         first_row = min(selected_rows)
-        granule_index = self.granule_table.item(first_row, 0).data(Qt.UserRole)
+        granule_index = self.granule_table.item(first_row, 0).data(
+            Qt.ItemDataRole.UserRole
+        )
         if granule_index is None or granule_index >= len(self._results):
             QMessageBox.warning(self, "Error", "No valid granule selected")
             return
@@ -1342,7 +1357,7 @@ class OperaDockWidget(QDockWidget):
             busy: True to show waiting cursor, False to restore normal cursor
         """
         if busy:
-            QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+            QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
             self.display_single_btn.setEnabled(False)
             self.display_mosaic_btn.setEnabled(False)
             self.download_single_layer_btn.setEnabled(False)
@@ -1550,7 +1565,9 @@ class OperaDockWidget(QDockWidget):
 
             total_granules = num_selected
             for idx, row in enumerate(sorted(selected_rows)):
-                granule_index = self.granule_table.item(row, 0).data(Qt.UserRole)
+                granule_index = self.granule_table.item(row, 0).data(
+                    Qt.ItemDataRole.UserRole
+                )
                 if granule_index is None or granule_index >= len(self._results):
                     self.progress_bar.setValue(idx + 1)
                     continue
@@ -1909,7 +1926,7 @@ class OperaDockWidget(QDockWidget):
 
         granules = []
         for row in sorted(selected_rows):
-            index = self.granule_table.item(row, 0).data(Qt.UserRole)
+            index = self.granule_table.item(row, 0).data(Qt.ItemDataRole.UserRole)
             if index is not None and index < len(self._results):
                 granules.append(self._results[index])
         return granules
@@ -2107,12 +2124,18 @@ class OperaDockWidget(QDockWidget):
                 if hasattr(worker, "cancel"):
                     try:
                         worker.cancel()
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        print(
+                            f"NASA OPERA: worker.cancel() failed: {exc}",
+                            file=sys.stderr,
+                        )
                 if hasattr(worker, "wait"):
                     try:
                         worker.wait()
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        print(
+                            f"NASA OPERA: worker.wait() failed: {exc}",
+                            file=sys.stderr,
+                        )
 
         event.accept()

--- a/nasa_opera/dialogs/settings_dock.py
+++ b/nasa_opera/dialogs/settings_dock.py
@@ -5,6 +5,8 @@ This module provides a settings panel for configuring the NASA OPERA plugin,
 including Earthdata credentials and display options.
 """
 
+import sys
+
 from qgis.PyQt.QtCore import Qt, QSettings
 from qgis.PyQt.QtWidgets import (
     QDockWidget,
@@ -44,7 +46,9 @@ class SettingsDockWidget(QDockWidget):
         self.iface = iface
         self.settings = QSettings()
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         self._setup_ui()
         self._load_settings()
@@ -65,7 +69,7 @@ class SettingsDockWidget(QDockWidget):
         header_font.setPointSize(12)
         header_font.setBold(True)
         header_label.setFont(header_font)
-        header_label.setAlignment(Qt.AlignCenter)
+        header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         header_label.setStyleSheet("color: #1565C0; padding: 5px;")
         layout.addWidget(header_label)
 
@@ -366,7 +370,7 @@ class SettingsDockWidget(QDockWidget):
 
         # Password
         self.password_input = QLineEdit()
-        self.password_input.setEchoMode(QLineEdit.Password)
+        self.password_input.setEchoMode(QLineEdit.EchoMode.Password)
         self.password_input.setPlaceholderText("Earthdata password")
         earthdata_layout.addRow("Password:", self.password_input)
 
@@ -577,7 +581,7 @@ class SettingsDockWidget(QDockWidget):
         auth_layout = QFormLayout(auth_group)
 
         self.ai_api_key_input = QLineEdit()
-        self.ai_api_key_input.setEchoMode(QLineEdit.Password)
+        self.ai_api_key_input.setEchoMode(QLineEdit.EchoMode.Password)
         self.ai_api_key_input.setPlaceholderText("Enter API key")
         auth_layout.addRow("API Key:", self.ai_api_key_input)
 
@@ -864,8 +868,9 @@ class SettingsDockWidget(QDockWidget):
                     "Please click 'Install AI Dependencies' first.",
                 )
                 return
-        except Exception:
-            pass
+        except Exception as exc:
+            # Dependency check is best-effort; fall through to existing behavior.
+            print(f"NASA OPERA: AI dependency check failed: {exc}", file=sys.stderr)
 
         provider_map = {
             "OpenAI": "openai",
@@ -974,11 +979,11 @@ class SettingsDockWidget(QDockWidget):
             self,
             "Clear Cache",
             f"Are you sure you want to clear the cache?\n{cache_dir}",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             import shutil
             import os
 
@@ -1201,11 +1206,11 @@ class SettingsDockWidget(QDockWidget):
             self,
             "Reset Settings",
             "Are you sure you want to reset all settings to defaults?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
         # Credentials - don't reset

--- a/nasa_opera/dialogs/update_checker.py
+++ b/nasa_opera/dialogs/update_checker.py
@@ -36,6 +36,19 @@ METADATA_URL = f"https://raw.githubusercontent.com/{GITHUB_REPO}/{GITHUB_BRANCH}
 ZIP_URL = f"https://github.com/{GITHUB_REPO}/archive/refs/heads/{GITHUB_BRANCH}.zip"
 
 
+def _require_https(url: str) -> None:
+    """Reject any URL that does not use the https scheme.
+
+    Args:
+        url: URL string to validate.
+
+    Raises:
+        ValueError: If the URL is not https.
+    """
+    if not url.lower().startswith("https://"):
+        raise ValueError(f"Refusing non-https URL: {url!r}")
+
+
 class VersionCheckWorker(QThread):
     """Worker thread for checking the latest version from GitHub."""
 
@@ -45,7 +58,8 @@ class VersionCheckWorker(QThread):
     def run(self):
         """Fetch the latest metadata from GitHub."""
         try:
-            with urlopen(METADATA_URL, timeout=15) as response:
+            _require_https(METADATA_URL)
+            with urlopen(METADATA_URL, timeout=15) as response:  # nosec B310
                 content = response.read().decode("utf-8")
 
             # Parse version from metadata
@@ -106,7 +120,8 @@ class DownloadWorker(QThread):
                     percent = min(int((downloaded / total_size) * 50), 50)
                     self.progress.emit(10 + percent, "Downloading...")
 
-            urlretrieve(ZIP_URL, zip_path, reporthook)
+            _require_https(ZIP_URL)
+            urlretrieve(ZIP_URL, zip_path, reporthook)  # nosec B310
 
             self.progress.emit(60, "Extracting files...")
 
@@ -230,7 +245,7 @@ class UpdateCheckerDialog(QDialog):
         header_font.setPointSize(14)
         header_font.setBold(True)
         header_label.setFont(header_font)
-        header_label.setAlignment(Qt.AlignCenter)
+        header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         header_label.setStyleSheet("color: #1565C0;")
         layout.addWidget(header_label)
 
@@ -276,7 +291,7 @@ class UpdateCheckerDialog(QDialog):
         # Progress label
         self.progress_label = QLabel("")
         self.progress_label.setVisible(False)
-        self.progress_label.setAlignment(Qt.AlignCenter)
+        self.progress_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.progress_label)
 
         # Buttons
@@ -317,7 +332,7 @@ class UpdateCheckerDialog(QDialog):
         )
         info_label.setWordWrap(True)
         info_label.setOpenExternalLinks(True)
-        info_label.setAlignment(Qt.AlignCenter)
+        info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(info_label)
 
     def check_for_updates(self):
@@ -405,11 +420,11 @@ class UpdateCheckerDialog(QDialog):
             f"This will download and install version {self.latest_version}.\n\n"
             "IMPORTANT: You will need to restart QGIS after the update completes.\n\n"
             "Do you want to continue?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
         self.check_btn.setEnabled(False)
@@ -490,10 +505,10 @@ class UpdateCheckerDialog(QDialog):
                 self,
                 "Download in Progress",
                 "A download is in progress. Are you sure you want to cancel?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
             )
-            if reply != QMessageBox.Yes:
+            if reply != QMessageBox.StandardButton.Yes:
                 event.ignore()
                 return
             self.download_worker.terminate()

--- a/nasa_opera/metadata.txt
+++ b/nasa_opera/metadata.txt
@@ -1,8 +1,9 @@
 [general]
 name=NASA OPERA
 qgisMinimumVersion=3.28
+qgisMaximumVersion=4.99
 description=Search and visualize NASA OPERA (Observational Products for End-Users from Remote Sensing Analysis) satellite data products.
-version=0.7.0
+version=0.8.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -46,6 +47,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.8.0
+        - Compatible with QGIS 4.0 (Qt6) while still supporting QGIS 3.28+ (Qt5)
     0.7.0
         - Add AI assistant for natural language OPERA data interaction (#19)
     0.6.0

--- a/nasa_opera/nasa_opera.py
+++ b/nasa_opera/nasa_opera.py
@@ -6,6 +6,7 @@ integration, menu items, toolbar buttons, and dockable panels.
 """
 
 import os
+import sys
 
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QIcon
@@ -212,10 +213,10 @@ class NasaOpera:
                         "that are not installed.\n\n"
                         "Would you like to open the Settings panel to "
                         "install them?",
-                        QMessageBox.Yes | QMessageBox.No,
-                        QMessageBox.Yes,
+                        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                        QMessageBox.StandardButton.Yes,
                     )
-                    if reply == QMessageBox.Yes:
+                    if reply == QMessageBox.StandardButton.Yes:
                         self.opera_action.setChecked(False)
                         self.toggle_settings_dock()
                         if self._settings_dock is not None:
@@ -223,8 +224,9 @@ class NasaOpera:
                         return
                     self.opera_action.setChecked(False)
                     return
-            except Exception:
-                pass  # Fall through to existing behavior
+            except Exception as exc:
+                # Dependency check is best-effort; fall through to existing behavior.
+                print(f"NASA OPERA: dependency check failed: {exc}", file=sys.stderr)
 
             try:
                 from .dialogs.opera_dock import OperaDockWidget
@@ -234,7 +236,9 @@ class NasaOpera:
                 self._opera_dock.visibilityChanged.connect(
                     self._on_opera_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._opera_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._opera_dock
+                )
                 self._opera_dock.show()
                 self._opera_dock.raise_()
                 return
@@ -272,10 +276,10 @@ class NasaOpera:
                         "AI Dependencies Missing",
                         "The AI Assistant requires the litellm package.\n\n"
                         "Would you like to open Settings to install it?",
-                        QMessageBox.Yes | QMessageBox.No,
-                        QMessageBox.Yes,
+                        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                        QMessageBox.StandardButton.Yes,
                     )
-                    if reply == QMessageBox.Yes:
+                    if reply == QMessageBox.StandardButton.Yes:
                         self.ai_chat_action.setChecked(False)
                         self.toggle_settings_dock()
                         if self._settings_dock is not None:
@@ -283,8 +287,9 @@ class NasaOpera:
                         return
                     self.ai_chat_action.setChecked(False)
                     return
-            except Exception:
-                pass
+            except Exception as exc:
+                # Dependency check is best-effort; fall through to existing behavior.
+                print(f"NASA OPERA: AI dependency check failed: {exc}", file=sys.stderr)
 
             try:
                 from .dialogs.ai_chat_dock import AIChatDockWidget
@@ -296,7 +301,9 @@ class NasaOpera:
                 self._ai_chat_dock.visibilityChanged.connect(
                     self._on_ai_chat_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._ai_chat_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._ai_chat_dock
+                )
                 self._ai_chat_dock.show()
                 self._ai_chat_dock.raise_()
                 return
@@ -334,7 +341,9 @@ class NasaOpera:
                 self._settings_dock.visibilityChanged.connect(
                     self._on_settings_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._settings_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
+                )
                 self._settings_dock.show()
                 self._settings_dock.raise_()
                 return
@@ -435,7 +444,7 @@ satellite observations.</p>
 
         try:
             dialog = UpdateCheckerDialog(self.plugin_dir, self.iface.mainWindow())
-            dialog.exec_()
+            dialog.exec()
         except Exception as e:
             QMessageBox.critical(
                 self.iface.mainWindow(),

--- a/nasa_opera/uv_manager.py
+++ b/nasa_opera/uv_manager.py
@@ -11,7 +11,7 @@ import os
 import sys
 import platform
 import stat
-import subprocess
+import subprocess  # nosec B404
 import tarfile
 import zipfile
 import tempfile
@@ -31,12 +31,13 @@ UV_DIR = os.path.join(CACHE_DIR, "uv")
 UV_VERSION = "0.10.6"
 
 
-def _log(message, level=Qgis.Info):
+def _log(message, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning,
+            Qgis.MessageLevel.Critical).
     """
     QgsMessageLog.logMessage(str(message), "NASA OPERA", level=level)
 
@@ -194,7 +195,7 @@ def download_uv(
                 )
             else:
                 error_msg = f"Download failed: {error_msg}"
-            _log(error_msg, Qgis.Critical)
+            _log(error_msg, Qgis.MessageLevel.Critical)
             return False, error_msg
 
         if cancel_check and cancel_check():
@@ -280,7 +281,7 @@ def download_uv(
         return False, "Download cancelled"
     except Exception as e:
         error_msg = f"uv installation failed: {str(e)}"
-        _log(error_msg, Qgis.Critical)
+        _log(error_msg, Qgis.MessageLevel.Critical)
         return False, error_msg
     finally:
         if os.path.exists(temp_path):
@@ -313,7 +314,8 @@ def verify_uv() -> Tuple[bool, str]:
             startupinfo.wShowWindow = subprocess.SW_HIDE
             kwargs["startupinfo"] = startupinfo
 
-        result = subprocess.run(
+        # uv_path resolved by us; argv is a fixed list; shell=False (default).
+        result = subprocess.run(  # nosec B603
             [uv_path, "--version"],
             capture_output=True,
             text=True,
@@ -328,7 +330,7 @@ def verify_uv() -> Tuple[bool, str]:
             return True, version_output
         else:
             error = result.stderr or "Unknown error"
-            _log(f"uv verification failed: {error}", Qgis.Warning)
+            _log(f"uv verification failed: {error}", Qgis.MessageLevel.Warning)
             return False, f"Verification failed: {error[:100]}"
 
     except subprocess.TimeoutExpired:
@@ -352,5 +354,5 @@ def remove_uv() -> Tuple[bool, str]:
         return True, "uv removed"
     except Exception as e:
         error_msg = f"Failed to remove uv: {str(e)}"
-        _log(error_msg, Qgis.Warning)
+        _log(error_msg, Qgis.MessageLevel.Warning)
         return False, error_msg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,84 @@
+"""Shared pytest fixtures.
+
+Stubs the ``qgis`` package so the plugin's modules can be imported without a
+running QGIS instance. The stub reproduces the real ``qgis.PyQt`` shim
+behavior on Qt6: it re-exports ``QAction``, ``QActionGroup`` and ``QShortcut``
+from ``PyQt6.QtGui`` under ``qgis.PyQt.QtWidgets`` (they moved out of
+``QtWidgets`` in Qt6).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import PyQt6.QtCore
+import PyQt6.QtGui
+import PyQt6.QtNetwork
+import PyQt6.QtWidgets
+
+
+def _install_qgis_stub() -> None:
+    qgis = types.ModuleType("qgis")
+    qgis.__path__ = []
+    sys.modules["qgis"] = qgis
+
+    qgis_pyqt = types.ModuleType("qgis.PyQt")
+    qgis_pyqt.__path__ = []
+    sys.modules["qgis.PyQt"] = qgis_pyqt
+    qgis.PyQt = qgis_pyqt
+
+    pyqt_submodules = {
+        "QtCore": PyQt6.QtCore,
+        "QtGui": PyQt6.QtGui,
+        "QtNetwork": PyQt6.QtNetwork,
+        "QtWidgets": PyQt6.QtWidgets,
+    }
+    for name, real in pyqt_submodules.items():
+        alias = types.ModuleType(f"qgis.PyQt.{name}")
+        for attr in dir(real):
+            if not attr.startswith("_"):
+                setattr(alias, attr, getattr(real, attr))
+        sys.modules[f"qgis.PyQt.{name}"] = alias
+        setattr(qgis_pyqt, name, alias)
+
+    # Qt6: QAction, QActionGroup, and QShortcut live in QtGui. The real
+    # qgis.PyQt.QtWidgets shim re-exports them, so mirror that here.
+    qtwidgets_alias = sys.modules["qgis.PyQt.QtWidgets"]
+    for attr in ("QAction", "QActionGroup", "QShortcut"):
+        setattr(qtwidgets_alias, attr, getattr(PyQt6.QtGui, attr))
+
+    for submodule in ("QtSvg", "QtWebEngineWidgets"):
+        alias = MagicMock()
+        sys.modules[f"qgis.PyQt.{submodule}"] = alias
+        setattr(qgis_pyqt, submodule, alias)
+
+    class _AutoMeta(type):
+        """Metaclass: any attribute access yields another auto-class."""
+
+        def __getattr__(cls, name: str):
+            sub = _AutoMeta(name, (object,), {})
+            setattr(cls, name, sub)
+            return sub
+
+    class _AutoTypeModule(types.ModuleType):
+        """Module whose attribute access returns a real ``type``.
+
+        Plain MagicMock breaks ``class Foo(QgsX): ...`` and
+        ``pyqtSignal(QgsX)`` because they require a real Python class.
+        Nested attribute access (e.g. ``Qgis.MessageLevel.Info``) yields
+        further auto-classes via the metaclass below.
+        """
+
+        def __getattr__(self, name: str):
+            cls = _AutoMeta(name, (object,), {})
+            setattr(self, name, cls)
+            return cls
+
+    for name in ("core", "gui", "utils"):
+        stub = _AutoTypeModule(f"qgis.{name}")
+        stub.__spec__ = None
+        sys.modules[f"qgis.{name}"] = stub
+        setattr(qgis, name, stub)
+
+
+_install_qgis_stub()

--- a/tests/test_pyqt6_imports.py
+++ b/tests/test_pyqt6_imports.py
@@ -1,0 +1,54 @@
+"""Import-smoke tests that verify every plugin module loads under PyQt6.
+
+This catches short-form Qt enum regressions (for example ``Qt.AlignCenter``
+instead of ``Qt.AlignmentFlag.AlignCenter``) which raise ``AttributeError`` in
+PyQt6 during class-body evaluation.
+
+The plugin package is auto-discovered: the first sibling directory of
+``tests/`` that contains a ``metadata.txt`` is treated as the plugin root,
+so this file does not need to be edited per-plugin.
+"""
+
+import importlib
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _find_plugin_root() -> pathlib.Path:
+    """Return the plugin package directory (the one with metadata.txt)."""
+    candidates = [
+        p.parent for p in REPO_ROOT.glob("*/metadata.txt") if p.parent.name != "tests"
+    ]
+    if not candidates:
+        raise RuntimeError(
+            "Could not locate a QGIS plugin package (no */metadata.txt found "
+            f"under {REPO_ROOT})."
+        )
+    if len(candidates) > 1:
+        raise RuntimeError(
+            f"Multiple plugin packages found under {REPO_ROOT}: {candidates}. "
+            "Set PLUGIN_ROOT explicitly in this file."
+        )
+    return candidates[0]
+
+
+PLUGIN_ROOT = _find_plugin_root()
+
+
+def _module_names():
+    """Yield dotted module names for every .py file under the plugin package."""
+    for path in sorted(PLUGIN_ROOT.rglob("*.py")):
+        rel = path.relative_to(PLUGIN_ROOT.parent).with_suffix("")
+        parts = rel.parts
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        yield ".".join(parts)
+
+
+@pytest.mark.parametrize("module_name", list(_module_names()))
+def test_module_imports_under_pyqt6(module_name):
+    """Each plugin module must import cleanly when qgis.PyQt maps to PyQt6."""
+    importlib.import_module(module_name)


### PR DESCRIPTION
## Summary

- Qualifies all Qt and QGIS core enums to the Qt6 fully-qualified form (works on PyQt5 >= 5.15 and PyQt6) and replaces `.exec_()` with `.exec()`.
- Bumps `qgisMaximumVersion` to `4.99` and `version` to `0.8.0` so the plugin appears on the [QGIS 4 Ready](https://plugins.qgis.org/plugins/new_qgis_ready/) list while still loading on QGIS 3.28+.
- Resolves every Bandit finding raised by the plugins.qgis.org upload scan; adds Bandit to pre-commit and CI; adds a PyQt6 import-smoke test suite plus a GitHub Actions workflow (pre-commit, Bandit, smoke tests across Python 3.10-3.13).

Migration follows:
- https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6
- https://plugins.qgis.org/docs/migrate-qgis4

## Test plan

- [x] `pre-commit run --all-files` clean (includes Bandit hook)
- [x] `bandit -r nasa_opera` reports `No issues identified.`
- [x] `pytest tests/ -v` passes 15 import-smoke tests under PyQt6
- [x] `python -m compileall nasa_opera/` succeeds
- [ ] Install branch into QGIS 3.28+ (Qt5): toolbar, dock toggles, search dialog, settings dialog, AI assistant dock, update checker
- [ ] Install branch into a QGIS 4.0 nightly (Qt6): repeat the same checks, paying attention to keyboard shortcuts (`Key.Key_Return + KeyboardModifier.ShiftModifier` in chat dock), `QMessageBox` confirmation buttons, and the `QgsRubberBand` rectangle map tool