### PR TITLE
Address Copilot review feedback from PR #20

### DIFF
--- a/nasa_opera/ai/oauth.py
+++ b/nasa_opera/ai/oauth.py
@@ -19,6 +19,8 @@ from typing import Callable, Dict, Optional, Tuple
 from qgis.PyQt.QtCore import QSettings, QUrl
 from qgis.PyQt.QtGui import QDesktopServices
 
+from ..utils.net import require_https
+
 # OAuth configuration per provider
 # These endpoints should be updated when official OAuth endpoints are available
 OAUTH_CONFIG = {
@@ -37,17 +39,18 @@ OAUTH_CONFIG = {
 }
 
 
-def _require_https(url: str) -> None:
-    """Reject any URL that does not use the https scheme.
+def _validate_oauth_config() -> None:
+    """Validate configured OAuth endpoints.
 
-    Args:
-        url: URL string to validate.
-
-    Raises:
-        ValueError: If the URL is not https.
+    Ensures both authorization and token endpoints use HTTPS so the
+    authorization flow cannot be started with an insecure endpoint.
     """
-    if not url.lower().startswith("https://"):
-        raise ValueError(f"Refusing non-https URL: {url!r}")
+    for config in OAUTH_CONFIG.values():
+        require_https(config["auth_url"])
+        require_https(config["token_url"])
+
+
+_validate_oauth_config()
 
 
 def _generate_pkce_pair() -> Tuple[str, str]:
@@ -237,7 +240,7 @@ class OAuthFlow:
             }
         ).encode("utf-8")
 
-        _require_https(config["token_url"])
+        require_https(config["token_url"])
         req = urllib.request.Request(
             config["token_url"],
             data=data,

--- a/nasa_opera/dialogs/update_checker.py
+++ b/nasa_opera/dialogs/update_checker.py
@@ -28,25 +28,14 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.PyQt.QtGui import QFont
 
+from ..utils.net import require_https
+
 # GitHub URLs for the plugin
 GITHUB_REPO = "opengeos/qgis-nasa-opera-plugin"
 GITHUB_BRANCH = "main"
 PLUGIN_PATH = "nasa_opera"
 METADATA_URL = f"https://raw.githubusercontent.com/{GITHUB_REPO}/{GITHUB_BRANCH}/{PLUGIN_PATH}/metadata.txt"
 ZIP_URL = f"https://github.com/{GITHUB_REPO}/archive/refs/heads/{GITHUB_BRANCH}.zip"
-
-
-def _require_https(url: str) -> None:
-    """Reject any URL that does not use the https scheme.
-
-    Args:
-        url: URL string to validate.
-
-    Raises:
-        ValueError: If the URL is not https.
-    """
-    if not url.lower().startswith("https://"):
-        raise ValueError(f"Refusing non-https URL: {url!r}")
 
 
 class VersionCheckWorker(QThread):
@@ -58,7 +47,7 @@ class VersionCheckWorker(QThread):
     def run(self):
         """Fetch the latest metadata from GitHub."""
         try:
-            _require_https(METADATA_URL)
+            require_https(METADATA_URL)
             with urlopen(METADATA_URL, timeout=15) as response:  # nosec B310
                 content = response.read().decode("utf-8")
 
@@ -115,12 +104,14 @@ class DownloadWorker(QThread):
             self.progress.emit(10, "Downloading plugin from GitHub...")
 
             def reporthook(block_num, block_size, total_size):
+                if self.isInterruptionRequested():
+                    raise InterruptedError("Download cancelled by user")
                 if total_size > 0:
                     downloaded = block_num * block_size
                     percent = min(int((downloaded / total_size) * 50), 50)
                     self.progress.emit(10 + percent, "Downloading...")
 
-            _require_https(ZIP_URL)
+            require_https(ZIP_URL)
             urlretrieve(ZIP_URL, zip_path, reporthook)  # nosec B310
 
             self.progress.emit(60, "Extracting files...")
@@ -495,10 +486,14 @@ class UpdateCheckerDialog(QDialog):
 
     def closeEvent(self, event):
         """Handle dialog close event."""
-        # Stop any running workers
+        # Stop any running workers cooperatively. terminate() can leave
+        # locks/files in an undefined state, so request interruption and
+        # wait for the worker to exit on its own. The check worker has a
+        # 15-second urlopen timeout; the download worker checks
+        # isInterruptionRequested() in its progress reporthook.
         if self.check_worker and self.check_worker.isRunning():
-            self.check_worker.terminate()
-            self.check_worker.wait()
+            self.check_worker.requestInterruption()
+            self.check_worker.wait(20000)
 
         if self.download_worker and self.download_worker.isRunning():
             reply = QMessageBox.question(
@@ -511,7 +506,7 @@ class UpdateCheckerDialog(QDialog):
             if reply != QMessageBox.StandardButton.Yes:
                 event.ignore()
                 return
-            self.download_worker.terminate()
-            self.download_worker.wait()
+            self.download_worker.requestInterruption()
+            self.download_worker.wait(30000)
 
         event.accept()

--- a/nasa_opera/utils/__init__.py
+++ b/nasa_opera/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities for the NASA OPERA plugin."""

--- a/nasa_opera/utils/net.py
+++ b/nasa_opera/utils/net.py
@@ -1,0 +1,14 @@
+"""Shared networking helpers for the NASA OPERA plugin."""
+
+
+def require_https(url: str) -> None:
+    """Reject any URL that does not use the https scheme.
+
+    Args:
+        url: URL string to validate.
+
+    Raises:
+        ValueError: If the URL is not https.
+    """
+    if not url.lower().startswith("https://"):
+        raise ValueError(f"Refusing non-https URL: {url!r}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,4 +81,15 @@ def _install_qgis_stub() -> None:
         setattr(qgis, name, stub)
 
 
-_install_qgis_stub()
+def _real_qgis_available() -> bool:
+    """Return True if the real ``qgis`` package can be imported."""
+    try:
+        import qgis  # noqa: F401
+        import qgis.PyQt  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+if not _real_qgis_available():
+    _install_qgis_stub()


### PR DESCRIPTION
Follow-up to #20. Addresses the four Copilot review comments left on that (now-merged) PR.

## Summary

- Gate the `qgis` stub in `tests/conftest.py` behind an `import qgis` probe so the suite can run inside a real QGIS Python environment without the stub masking real import issues.
- Extract `require_https()` into a shared `nasa_opera/utils/net.py` and use it from both `oauth.py` and `update_checker.py` (was duplicated).
- Validate every configured `auth_url` and `token_url` in `OAUTH_CONFIG` at import time via `_validate_oauth_config()`, so the OAuth flow cannot be launched against an http endpoint.
- Replace `QThread.terminate()` in the update-checker `closeEvent` with cooperative cancellation (`requestInterruption()` + bounded `wait()`); the download reporthook now checks `isInterruptionRequested()` so a cancel during a download aborts cleanly instead of leaving partial files.

## Test plan

- [x] `pre-commit run --files <changed>` clean (incl. Bandit hook)
- [x] `bandit -r nasa_opera` reports `No issues identified.`
- [x] `pytest tests/ -v` passes 17 import-smoke tests under PyQt6 (now includes `nasa_opera.utils` and `nasa_opera.utils.net`)
- [ ] Manual: open Check for Updates in QGIS, start a download, close the dialog mid-download and confirm the worker exits cleanly without crashing