### PR TITLE
Revert AI model list update (Gemini 404 regression)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ The AI assistant can search data, display footprints, load rasters, create mosai
 
 | Provider | Default Model | API Key Required |
 |----------|--------------|-----------------|
-| OpenAI | gpt-5.5 | Yes |
+| OpenAI | gpt-4.1 | Yes |
 | Anthropic | claude-sonnet-4-6 | Yes |
 | Amazon Bedrock | claude-sonnet-4-20250514 | AWS credentials |
-| Google Gemini | gemini-3.1-flash-lite-preview | Yes |
-| Ollama | llama3.1 | No (local) |
+| Google Gemini | gemini-2.5-flash | Yes |
+| Ollama | llama3.3 | No (local) |
 
 ### Settings
 

--- a/nasa_opera/ai/llm_client.py
+++ b/nasa_opera/ai/llm_client.py
@@ -13,20 +13,24 @@ DEFAULT_MODELS = {
     "openai": "gpt-4.1",
     "anthropic": "claude-sonnet-4-6",
     "bedrock": "anthropic.claude-sonnet-4-20250514-v1:0",
-    "gemini": "gemini-3.1-flash-lite-preview",
-    "ollama": "llama3.1",
+    "gemini": "gemini-2.5-flash",
+    "ollama": "llama3.3",
 }
 
 # Available models per provider
 AVAILABLE_MODELS = {
     "openai": [
-        "gpt-5.5",
-        "gpt-5.4",
-        "gpt-5.4-mini",
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4.1-nano",
+        "o4-mini",
+        "o3-mini",
+        "gpt-4o",
+        "gpt-4o-mini",
     ],
     "anthropic": [
         "claude-sonnet-4-6",
-        "claude-opus-4-7",
+        "claude-opus-4-6",
         "claude-haiku-4-5-20251001",
     ],
     "bedrock": [
@@ -35,12 +39,12 @@ AVAILABLE_MODELS = {
         "anthropic.claude-haiku-4-5-20251001-v1:0",
     ],
     "gemini": [
-        "gemini-3.1-flash-lite-preview",
-        "gemini-3.1-pro-preview",
-        "gemini-3-flash-preview",
+        "gemini-2.5-flash",
+        "gemini-2.5-pro",
+        "gemini-2.0-flash",
     ],
     "ollama": [
-        "llama3.1",
+        "llama3.3",
         "qwen3",
         "gemma3",
         "deepseek-r1",

--- a/nasa_opera/metadata.txt
+++ b/nasa_opera/metadata.txt
@@ -3,7 +3,7 @@ name=NASA OPERA
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Search and visualize NASA OPERA (Observational Products for End-Users from Remote Sensing Analysis) satellite data products.
-version=0.8.0
+version=0.8.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -47,6 +47,10 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.8.2
+        - Revert AI model list update (Gemini Test Connection 404 regression in 0.8.1)
+    0.8.1
+        - Update AI models in README and LLM client
     0.8.0
         - Compatible with QGIS 4.0 (Qt6) while still supporting QGIS 3.28+ (Qt5)
     0.7.0

--- a/nasa_opera/metadata.txt
+++ b/nasa_opera/metadata.txt
@@ -3,7 +3,7 @@ name=NASA OPERA
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Search and visualize NASA OPERA (Observational Products for End-Users from Remote Sensing Analysis) satellite data products.
-version=0.8.1
+version=0.8.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -47,8 +47,6 @@ experimental=False
 deprecated=False
 
 changelog=
-    0.8.1
-        - Update AI models in README and LLM client
     0.8.0
         - Compatible with QGIS 4.0 (Qt6) while still supporting QGIS 3.28+ (Qt5)
     0.7.0


### PR DESCRIPTION
## Summary

- Reverts d1f1f64 (#22), which replaced the previously-working AI provider model lists with values that broke Gemini Test Connection — every model attempted (`gemini-3.1-flash-lite-preview`, `gemini-3.1-flash-live-preview`, even the stable `gemini-2.5-flash`) returns `litellm.NotFoundError: GeminiException - 404 page not found` from QGIS.
- Restores the v0.8.0 model lists across `nasa_opera/ai/llm_client.py` and `README.md`.
- Bumps `nasa_opera/metadata.txt` forward to **0.8.2** (instead of letting the revert roll back to 0.8.0) since 0.8.1 is already published on plugins.qgis.org, with a corresponding changelog entry.

After this lands, the Gemini default returns to `gemini-2.5-flash`, which was empirically working for users of 0.8.0.

## Test plan

- [x] `conda run -n geo pre-commit run --all-files` — passes
- [x] `conda run -n geo pytest tests/test_pyqt6_imports.py -v` — 17/17 passed
- [ ] In QGIS: NASA OPERA Settings → AI Assistant → Provider: Google Gemini → manually pick `gemini-2.5-flash` from the Model dropdown (the previously-saved invalid value sticks via `setEditText`, so a one-time re-pick is required) → click Test Connection → expect "Connected successfully. Response: ..."
- [ ] Verify the OpenAI / Anthropic / Ollama dropdowns also show their pre-d1f1f64 entries (e.g. `gpt-4.1` family for OpenAI, `llama3.3` for Ollama).

## Follow-up (out of scope here)

A forward-looking model refresh — adopting newer OpenAI / Gemini / Ollama IDs with each one verified against the live providers — should be a separate PR after this revert is merged and confirmed working.