### PR TITLE
feat: add one-click dependency installer in Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,16 @@ To access NASA OPERA data, you need a free NASA Earthdata account:
 
 ### Python Dependencies
 
-Install these packages in the QGIS Python environment, or in an environment
-available on the QGIS Python path:
+Open **NASA OPERA > Settings > Dependencies** and click **Install Dependencies**
+to install these packages in an isolated plugin environment:
 
 - `earthaccess` - NASA Earthdata search and download
 - `geopandas` - Geospatial data manipulation
 - `shapely` - Geometry operations
 - `pandas` - Data analysis
+
+The isolated environment is created under `~/.qgis_nasa_opera/` and is added
+to the plugin path automatically when QGIS loads NASA OPERA.
 
 ## Installation
 
@@ -140,6 +143,7 @@ installation.
 
 Access settings via **NASA OPERA > Settings**:
 
+- **Dependencies**: Install and verify required Python packages
 - **Credentials**: Configure your NASA Earthdata username and password
 - **Display**: Customize footprint styles and default colormap
 - **Advanced**: Set default search parameters and cache options
@@ -162,7 +166,8 @@ qgis-nasa-opera-plugin/
 │   ├── __init__.py            # Plugin entry point
 │   ├── nasa_opera.py          # Main plugin class
 │   ├── metadata.txt           # Plugin metadata
-│   ├── deps_manager.py        # Dependency checks
+│   ├── deps_manager.py        # Dependency checks and installer
+│   ├── uv_manager.py          # uv bootstrap helper for dependency installs
 │   ├── dialogs/               # UI widgets
 │   │   ├── opera_dock.py      # Main search interface
 │   │   ├── settings_dock.py   # Settings panel

--- a/nasa_opera/deps_manager.py
+++ b/nasa_opera/deps_manager.py
@@ -1,18 +1,30 @@
 """
-Dependency checks for NASA OPERA Plugin.
+Dependency Manager for NASA OPERA Plugin.
 
-The plugin no longer installs Python packages itself. It still checks whether
-the required packages are importable and, for users upgrading from older
-versions, adds the legacy plugin virtual environment to ``sys.path`` when it
-already exists.
+Manages a virtual environment for plugin dependencies
+to avoid polluting the QGIS built-in Python environment.
+
+The venv is created at ~/.qgis_nasa_opera/venv_pyX.Y and its
+site-packages directory is added to sys.path at runtime.
+
+All ``subprocess`` calls in this module use list-form argv built from
+internal constants (the resolved Python interpreter, the resolved ``uv``
+binary, fixed flags) and never accept user-supplied input or run with
+``shell=True``. The ``# nosec`` annotations on the import and call sites
+document this explicitly for the plugins.qgis.org Bandit scan.
 """
 
 import importlib
 import os
+import platform
+import shutil
+import subprocess  # nosec B404
 import sys
-from typing import Dict, List, Optional
+import time
+from typing import Callable, Dict, List, Optional, Tuple
 
-# Required packages: (import_name, pip_install_name)
+from qgis.PyQt.QtCore import QThread, pyqtSignal
+
 REQUIRED_PACKAGES = [
     ("earthaccess", "earthaccess"),
     ("geopandas", "geopandas"),
@@ -25,12 +37,23 @@ PYTHON_VERSION = f"py{sys.version_info.major}.{sys.version_info.minor}"
 
 
 def get_venv_dir() -> str:
-    """Return the legacy plugin virtual environment directory."""
+    """Get the path to the plugin's virtual environment directory.
+
+    Returns:
+        Path to the venv directory (~/.qgis_nasa_opera/venv_pyX.Y).
+    """
     return os.path.join(CACHE_DIR, f"venv_{PYTHON_VERSION}")
 
 
 def get_venv_python_path(venv_dir: Optional[str] = None) -> str:
-    """Return the Python executable path inside the legacy venv."""
+    """Get the path to the Python executable inside the venv.
+
+    Args:
+        venv_dir: Path to the venv directory. Defaults to get_venv_dir().
+
+    Returns:
+        Path to the venv's Python executable.
+    """
     if venv_dir is None:
         venv_dir = get_venv_dir()
     if sys.platform == "win32":
@@ -39,12 +62,20 @@ def get_venv_python_path(venv_dir: Optional[str] = None) -> str:
 
 
 def get_venv_site_packages(venv_dir: Optional[str] = None) -> str:
-    """Return the site-packages path inside the legacy venv."""
+    """Get the path to the venv's site-packages directory.
+
+    Args:
+        venv_dir: Path to the venv directory. Defaults to get_venv_dir().
+
+    Returns:
+        Path to the venv's site-packages directory.
+    """
     if venv_dir is None:
         venv_dir = get_venv_dir()
     if sys.platform == "win32":
         return os.path.join(venv_dir, "Lib", "site-packages")
 
+    # On Unix, detect the actual Python version directory
     lib_dir = os.path.join(venv_dir, "lib")
     if os.path.isdir(lib_dir):
         for entry in sorted(os.listdir(lib_dir)):
@@ -53,19 +84,32 @@ def get_venv_site_packages(venv_dir: Optional[str] = None) -> str:
                 if os.path.isdir(candidate):
                     return candidate
 
+    # Fallback using current Python version
     py_ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
     return os.path.join(venv_dir, "lib", py_ver, "site-packages")
 
 
 def venv_exists() -> bool:
-    """Return True when the legacy plugin venv exists."""
+    """Check if the plugin's virtual environment exists and has a Python executable.
+
+    Returns:
+        True if the venv directory and Python executable exist.
+    """
     venv_dir = get_venv_dir()
     python_path = get_venv_python_path(venv_dir)
     return os.path.isdir(venv_dir) and os.path.isfile(python_path)
 
 
 def ensure_venv_packages_available() -> bool:
-    """Add legacy venv site-packages to ``sys.path`` when present."""
+    """Add the venv's site-packages to sys.path if the venv exists.
+
+    This is safe to call multiple times (idempotent). If the venv does not
+    exist yet, this is a no-op.
+
+    Returns:
+        True if site-packages was added or already present, False if venv
+        does not exist.
+    """
     if not venv_exists():
         return False
 
@@ -76,7 +120,11 @@ def ensure_venv_packages_available() -> bool:
 
 
 def check_dependencies() -> List[Dict]:
-    """Check whether required Python packages are importable."""
+    """Check if required Python packages are importable.
+
+    Returns:
+        List of dicts with keys: name, pip_name, installed, version.
+    """
     results = []
     for import_name, pip_name in REQUIRED_PACKAGES:
         info: Dict = {
@@ -96,10 +144,552 @@ def check_dependencies() -> List[Dict]:
 
 
 def all_dependencies_met() -> bool:
-    """Return True if all required packages are importable."""
+    """Return True if all required packages are importable.
+
+    Returns:
+        True if all dependencies are installed and importable.
+    """
     return all(dep["installed"] for dep in check_dependencies())
 
 
 def get_missing_packages() -> List[str]:
-    """Return pip install names for missing packages."""
+    """Return pip install names of missing packages.
+
+    Returns:
+        List of pip package names that are not currently importable.
+    """
     return [dep["pip_name"] for dep in check_dependencies() if not dep["installed"]]
+
+
+def _get_clean_env() -> dict:
+    """Get a clean copy of the environment for subprocess calls.
+
+    Removes variables that could interfere with venv creation and pip installs.
+
+    Returns:
+        A copy of os.environ with problematic variables removed.
+    """
+    env = os.environ.copy()
+    for var in [
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "VIRTUAL_ENV",
+        "QGIS_PREFIX_PATH",
+        "QGIS_PLUGINPATH",
+    ]:
+        env.pop(var, None)
+    env["PYTHONIOENCODING"] = "utf-8"
+    return env
+
+
+def _get_subprocess_kwargs() -> dict:
+    """Get platform-specific subprocess keyword arguments.
+
+    On Windows, suppresses the console window that would otherwise pop up
+    for each subprocess invocation.
+
+    Returns:
+        Dict of kwargs to pass to subprocess.run().
+    """
+    if platform.system() == "Windows":
+        return {"creationflags": subprocess.CREATE_NO_WINDOW}
+    return {}
+
+
+def _find_python_executable() -> str:
+    """Find a working Python executable for subprocess calls.
+
+    On QGIS Windows, ``sys.executable`` may point to ``qgis-bin.exe`` rather
+    than a Python interpreter, which would launch another QGIS instance when
+    used in subprocess calls. This function searches for the actual Python
+    executable using multiple strategies.
+
+    Returns:
+        Path to a Python executable, or ``sys.executable`` as fallback.
+    """
+    if platform.system() != "Windows":
+        return sys.executable
+
+    # Strategy 1: Check if sys.executable is already Python
+    exe_name = os.path.basename(sys.executable).lower()
+    if exe_name in ("python.exe", "python3.exe"):
+        return sys.executable
+
+    # Strategy 2: Use sys._base_prefix to find the Python installation.
+    # On QGIS Windows, sys._base_prefix typically points to
+    # C:\Program Files\QGIS 3.x\apps\Python3x\
+    base_prefix = getattr(sys, "_base_prefix", None) or sys.prefix
+    python_in_prefix = os.path.join(base_prefix, "python.exe")
+    if os.path.isfile(python_in_prefix):
+        return python_in_prefix
+
+    # Strategy 3: Look for python.exe next to sys.executable
+    exe_dir = os.path.dirname(sys.executable)
+    for name in ("python.exe", "python3.exe"):
+        candidate = os.path.join(exe_dir, name)
+        if os.path.isfile(candidate):
+            return candidate
+
+    # Strategy 4: Walk up from sys.executable to find apps/Python3x/python.exe
+    # Typical QGIS layout: .../QGIS 3.x/bin/qgis-bin.exe
+    #                       .../QGIS 3.x/apps/Python3x/python.exe
+    parent = os.path.dirname(exe_dir)
+    apps_dir = os.path.join(parent, "apps")
+    if os.path.isdir(apps_dir):
+        best_candidate = None
+        best_version_num = -1
+        for entry in os.listdir(apps_dir):
+            lower_entry = entry.lower()
+            if not lower_entry.startswith("python"):
+                continue
+            suffix = lower_entry.removeprefix("python")
+            digits = "".join(ch for ch in suffix if ch.isdigit())
+            if not digits:
+                continue
+            try:
+                version_num = int(digits)
+            except ValueError:
+                continue
+            candidate = os.path.join(apps_dir, entry, "python.exe")
+            if os.path.isfile(candidate) and version_num > best_version_num:
+                best_version_num = version_num
+                best_candidate = candidate
+        if best_candidate:
+            return best_candidate
+
+    # Strategy 5: Use shutil.which as last resort
+    which_python = shutil.which("python")
+    if which_python:
+        return which_python
+
+    return sys.executable
+
+
+def _create_venv_with_env_builder(venv_dir: str) -> bool:
+    """Attempt to create a virtual environment using venv.EnvBuilder (in-process).
+
+    .. warning::
+        ``EnvBuilder`` internally uses ``sys.executable`` to copy the Python
+        binary into the venv.  On QGIS Windows ``sys.executable`` is
+        ``qgis-bin.exe``, so this would copy QGIS itself and later subprocess
+        calls would launch a new QGIS instance.  Therefore this function is
+        **skipped** when ``sys.executable`` does not look like a Python
+        interpreter.
+
+    Args:
+        venv_dir: Path where the venv should be created.
+
+    Returns:
+        True if the venv was created and the Python executable exists.
+    """
+    # Guard: only safe when sys.executable is actually Python.
+    exe_name = os.path.basename(sys.executable).lower()
+    if exe_name not in ("python.exe", "python3.exe", "python", "python3"):
+        return False
+
+    try:
+        import venv as venv_mod
+
+        builder = venv_mod.EnvBuilder(with_pip=True)
+        builder.create(venv_dir)
+        return os.path.isfile(get_venv_python_path(venv_dir))
+    except Exception:
+        return False
+
+
+def _try_copy_python_executable(venv_dir: str) -> bool:
+    """Copy the current Python executable into the venv as a recovery step.
+
+    This handles the case where venv creation produced the directory structure
+    but did not place the Python executable (known to happen with QGIS's
+    embedded Python on Windows).
+
+    Args:
+        venv_dir: Path to the venv directory.
+
+    Returns:
+        True if the Python executable now exists at the expected path.
+    """
+    python_path = get_venv_python_path(venv_dir)
+    if os.path.isfile(python_path):
+        return True
+
+    target_dir = os.path.dirname(python_path)
+    os.makedirs(target_dir, exist_ok=True)
+
+    try:
+        shutil.copy2(_find_python_executable(), python_path)
+        return os.path.isfile(python_path)
+    except (OSError, shutil.SameFileError):
+        return False
+
+
+def _cleanup_partial_venv(venv_dir: str) -> None:
+    """Remove a partially created venv directory (best-effort).
+
+    Args:
+        venv_dir: Path to the venv directory to clean up.
+    """
+    if os.path.isdir(venv_dir):
+        try:
+            shutil.rmtree(venv_dir)
+        except OSError:
+            pass
+
+
+def _verify_pip_and_return(python_path: str) -> str:
+    """Ensure pip is available in the venv and return the python path.
+
+    Args:
+        python_path: Path to the venv's Python executable.
+
+    Returns:
+        The *python_path* if pip is verified.
+
+    Raises:
+        RuntimeError: If pip cannot be made available.
+    """
+    env = _get_clean_env()
+    kwargs = _get_subprocess_kwargs()
+
+    # Try ensurepip (may already be present from EnvBuilder)
+    subprocess.run(  # nosec B603
+        [python_path, "-m", "ensurepip", "--upgrade"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+        **kwargs,
+    )
+
+    # Verify pip works
+    result = subprocess.run(  # nosec B603
+        [python_path, "-m", "pip", "--version"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+        **kwargs,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "pip is not available in the virtual environment.\n"
+            f"Python path: {python_path}\n"
+            f"Error: {result.stderr or result.stdout}"
+        )
+
+    return python_path
+
+
+def create_venv(venv_dir: str) -> str:
+    """Create a virtual environment at the specified path.
+
+    When uv is available, uses ``uv venv`` which is faster and does not
+    require pip to be bootstrapped inside the venv.
+
+    Otherwise uses a multi-strategy approach to handle embedded Python
+    environments (e.g. QGIS on Windows) where ``sys.executable`` may point
+    to ``qgis-bin.exe`` rather than ``python.exe``.
+
+    Pip fallback strategy order:
+        1. Subprocess using the real Python executable found by
+           ``_find_python_executable()`` (primary, works on Windows QGIS).
+        2. In-process ``venv.EnvBuilder`` (fallback, only when
+           ``sys.executable`` is already a Python interpreter).
+        3. Recovery: copy the real Python executable into the venv when the
+           directory was created but the executable is missing.
+
+    Args:
+        venv_dir: Path where the venv should be created.
+
+    Returns:
+        Path to the Python executable inside the newly created venv.
+
+    Raises:
+        RuntimeError: If venv creation fails after all strategies.
+    """
+    from .uv_manager import get_uv_path, uv_exists
+
+    os.makedirs(os.path.dirname(venv_dir), exist_ok=True)
+
+    python_path = get_venv_python_path(venv_dir)
+    env = _get_clean_env()
+    kwargs = _get_subprocess_kwargs()
+
+    # Strategy 0: Use uv venv when available (fastest, no pip needed)
+    if uv_exists():
+        uv_path = get_uv_path()
+        python_exe = _find_python_executable()
+        cmd = [uv_path, "venv", "--python", python_exe, venv_dir]
+        result = subprocess.run(  # nosec B603
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+            **kwargs,
+        )
+        if result.returncode == 0 and os.path.isfile(python_path):
+            return python_path
+        # uv venv failed — clean up and fall through to pip strategies
+        _cleanup_partial_venv(venv_dir)
+
+    # Strategy 1: Subprocess with the real Python executable
+    python_exe = _find_python_executable()
+    subprocess_error = ""
+
+    cmd = [python_exe, "-m", "venv", venv_dir]
+    result = subprocess.run(  # nosec B603
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+        **kwargs,
+    )
+
+    if result.returncode == 0 and os.path.isfile(python_path):
+        return _verify_pip_and_return(python_path)
+
+    if result.returncode != 0:
+        subprocess_error = result.stderr or result.stdout or ""
+
+    # Clean up partial venv before retrying
+    _cleanup_partial_venv(venv_dir)
+
+    # Strategy 2: In-process EnvBuilder (skipped when sys.executable is not Python)
+    if _create_venv_with_env_builder(venv_dir):
+        return _verify_pip_and_return(python_path)
+
+    _cleanup_partial_venv(venv_dir)
+
+    # Strategy 3: Create venv without pip, then copy Python executable if needed
+    strategy3_error = ""
+    try:
+        result2 = subprocess.run(  # nosec B603
+            [python_exe, "-m", "venv", "--without-pip", venv_dir],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+            **kwargs,
+        )
+        if result2.returncode == 0:
+            if not os.path.isfile(python_path):
+                _try_copy_python_executable(venv_dir)
+            if os.path.isfile(python_path):
+                return _verify_pip_and_return(python_path)
+        else:
+            strategy3_error = result2.stderr or result2.stdout or ""
+    except Exception as exc:
+        strategy3_error = f"{type(exc).__name__}: {exc}"
+
+    # All strategies failed
+    details = [
+        f"sys.executable: {sys.executable}",
+        f"Python found: {python_exe}",
+        f"Target venv: {venv_dir}",
+        f"Expected python: {python_path}",
+        f"Platform: {sys.platform}",
+    ]
+    if subprocess_error:
+        details.append(f"Subprocess error: {subprocess_error}")
+    if strategy3_error:
+        details.append(f"Strategy 3 error: {strategy3_error}")
+
+    raise RuntimeError(
+        "Failed to create virtual environment after trying multiple strategies.\n\n"
+        "This can happen when QGIS bundles Python in a way that prevents\n"
+        "standard venv creation.\n\n"
+        "You can try installing manually with:\n"
+        "  pip install earthaccess geopandas shapely pandas\n\n"
+        "Details:\n" + "\n".join(f"  {d}" for d in details)
+    )
+
+
+def install_packages(
+    venv_dir: str,
+    packages: List[str],
+    progress_callback: Optional[Callable[[int, str], None]] = None,
+) -> Tuple[bool, str]:
+    """Install packages into the virtual environment.
+
+    Uses uv when available for significantly faster installation,
+    falling back to pip otherwise.
+
+    Args:
+        venv_dir: Path to the venv directory.
+        packages: List of pip package names to install.
+        progress_callback: Optional callback for progress updates (percent, message).
+
+    Returns:
+        Tuple of (success, message).
+    """
+    from .uv_manager import get_uv_path, uv_exists
+
+    python_path = get_venv_python_path(venv_dir)
+    env = _get_clean_env()
+    kwargs = _get_subprocess_kwargs()
+
+    use_uv = uv_exists()
+    if use_uv:
+        uv_path = get_uv_path()
+        cmd = [
+            uv_path,
+            "pip",
+            "install",
+            "--python",
+            python_path,
+            "--upgrade",
+        ] + packages
+    else:
+        cmd = [
+            python_path,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "--disable-pip-version-check",
+            "--prefer-binary",
+        ] + packages
+
+    if progress_callback:
+        installer = "uv" if use_uv else "pip"
+        progress_callback(20, f"Installing ({installer}): {', '.join(packages)}...")
+
+    result = subprocess.run(  # nosec B603
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        env=env,
+        **kwargs,
+    )
+
+    if result.returncode != 0:
+        error_output = result.stderr or result.stdout or "Unknown error"
+        # Truncate long error messages
+        if len(error_output) > 1000:
+            error_output = "..." + error_output[-1000:]
+        installer = "uv pip" if use_uv else "pip"
+        return False, f"{installer} install failed:\n{error_output}"
+
+    return True, "Packages installed successfully."
+
+
+class DepsInstallWorker(QThread):
+    """Worker thread for creating a venv and installing dependencies."""
+
+    progress = pyqtSignal(int, str)
+    finished = pyqtSignal(bool, str)
+
+    def run(self):
+        """Execute uv download, venv creation, and dependency installation."""
+        try:
+            from .uv_manager import download_uv, uv_exists
+
+            start_time = time.time()
+            venv_dir = get_venv_dir()
+
+            # Step 0: Download uv if needed (fast package installer)
+            if not uv_exists():
+                self.progress.emit(2, "Downloading uv package installer...")
+                success, msg = download_uv(
+                    progress_callback=lambda p, m: self.progress.emit(
+                        2 + int(p * 0.03), m
+                    ),
+                )
+                if not success:
+                    # Non-fatal: fall back to pip
+                    self.progress.emit(5, "uv unavailable, using pip instead.")
+                else:
+                    self.progress.emit(5, "uv ready.")
+
+            # Step 1: Create venv if needed
+            if not venv_exists():
+                self.progress.emit(5, "Creating virtual environment...")
+                try:
+                    create_venv(venv_dir)
+                except RuntimeError as e:
+                    self.finished.emit(False, str(e))
+                    return
+            self.progress.emit(10, "Virtual environment ready.")
+
+            # Step 2: Verify pip (only needed when not using uv)
+            use_uv = uv_exists()
+            if not use_uv:
+                self.progress.emit(12, "Verifying pip...")
+                python_path = get_venv_python_path(venv_dir)
+                env = _get_clean_env()
+                kwargs = _get_subprocess_kwargs()
+
+                result = subprocess.run(  # nosec B603
+                    [python_path, "-m", "pip", "--version"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    env=env,
+                    **kwargs,
+                )
+                if result.returncode != 0:
+                    self.finished.emit(
+                        False,
+                        "pip is not available in the virtual environment.\n"
+                        "Please install dependencies manually:\n"
+                        "pip install earthaccess geopandas shapely pandas",
+                    )
+                    return
+            self.progress.emit(15, "Package installer ready.")
+
+            # Step 3: Install missing packages
+            missing = get_missing_packages()
+            if not missing:
+                self.finished.emit(True, "All dependencies are already installed.")
+                return
+
+            self.progress.emit(20, f"Installing: {', '.join(missing)}...")
+            success, message = install_packages(
+                venv_dir,
+                missing,
+                progress_callback=lambda p, m: self.progress.emit(
+                    20 + int(p * 0.65), m
+                ),
+            )
+            if not success:
+                self.finished.emit(False, message)
+                return
+            self.progress.emit(85, "Packages installed.")
+
+            # Step 4: Add venv to sys.path
+            self.progress.emit(90, "Configuring package paths...")
+            ensure_venv_packages_available()
+
+            # Step 5: Verify imports
+            self.progress.emit(95, "Verifying installations...")
+            still_missing = get_missing_packages()
+
+            elapsed = time.time() - start_time
+            if elapsed >= 60:
+                minutes, seconds = divmod(int(round(elapsed)), 60)
+                elapsed_str = f"{minutes}:{seconds:02d}"
+            else:
+                elapsed_str = f"{elapsed:.1f}s"
+
+            if still_missing:
+                self.finished.emit(
+                    False,
+                    f"The following packages could not be verified: "
+                    f"{', '.join(still_missing)}.\n"
+                    "You may need to restart QGIS for changes to take effect.",
+                )
+            else:
+                self.progress.emit(100, f"All dependencies installed in {elapsed_str}!")
+                self.finished.emit(
+                    True,
+                    f"All dependencies installed successfully in {elapsed_str}!",
+                )
+
+        except subprocess.TimeoutExpired:
+            self.finished.emit(False, "Installation timed out after 10 minutes.")
+        except Exception as e:
+            self.finished.emit(False, f"Unexpected error: {str(e)}")

--- a/nasa_opera/dialogs/settings_dock.py
+++ b/nasa_opera/dialogs/settings_dock.py
@@ -22,6 +22,7 @@ from qgis.PyQt.QtWidgets import (
     QMessageBox,
     QFileDialog,
     QTabWidget,
+    QProgressBar,
 )
 from qgis.PyQt.QtGui import QFont
 
@@ -42,6 +43,7 @@ class SettingsDockWidget(QDockWidget):
         super().__init__("NASA OPERA Settings", parent)
         self.iface = iface
         self.settings = QSettings()
+        self._deps_worker = None
 
         self.setAllowedAreas(
             Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
@@ -73,6 +75,10 @@ class SettingsDockWidget(QDockWidget):
         # Tab widget for organized settings
         self.tab_widget = QTabWidget()
         layout.addWidget(self.tab_widget)
+
+        # Dependencies tab (first, most important for new users)
+        dependencies_tab = self._create_dependencies_tab()
+        self.tab_widget.addTab(dependencies_tab, "Dependencies")
 
         # Credentials tab
         credentials_tab = self._create_credentials_tab()
@@ -118,6 +124,202 @@ class SettingsDockWidget(QDockWidget):
         self.status_label = QLabel("Settings loaded")
         self.status_label.setStyleSheet("color: gray; font-size: 10px;")
         layout.addWidget(self.status_label)
+
+    def _create_dependencies_tab(self):
+        """Create the dependencies management tab."""
+        from ..deps_manager import REQUIRED_PACKAGES
+
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+
+        info_label = QLabel(
+            "NASA OPERA requires the following Python packages.\n"
+            "Click 'Install Dependencies' to install them in an isolated\n"
+            "virtual environment that does not affect your QGIS Python."
+        )
+        info_label.setWordWrap(True)
+        info_label.setStyleSheet("font-size: 10px; padding: 5px;")
+        layout.addWidget(info_label)
+
+        deps_group = QGroupBox("Package Status")
+        deps_layout = QVBoxLayout(deps_group)
+
+        self.dep_status_labels = {}
+        for import_name, pip_name in REQUIRED_PACKAGES:
+            row_layout = QHBoxLayout()
+            name_label = QLabel(f"  {pip_name}")
+            name_label.setMinimumWidth(120)
+            status_label = QLabel("Checking...")
+            status_label.setStyleSheet("color: gray;")
+            row_layout.addWidget(name_label)
+            row_layout.addWidget(status_label)
+            row_layout.addStretch()
+            deps_layout.addLayout(row_layout)
+            self.dep_status_labels[import_name] = status_label
+
+        layout.addWidget(deps_group)
+
+        self.deps_overall_label = QLabel("Checking dependencies...")
+        self.deps_overall_label.setWordWrap(True)
+        self.deps_overall_label.setStyleSheet("font-weight: bold; padding: 5px;")
+        layout.addWidget(self.deps_overall_label)
+
+        self.deps_progress_bar = QProgressBar()
+        self.deps_progress_bar.setRange(0, 100)
+        self.deps_progress_bar.setVisible(False)
+        layout.addWidget(self.deps_progress_bar)
+
+        self.deps_progress_label = QLabel("")
+        self.deps_progress_label.setWordWrap(True)
+        self.deps_progress_label.setStyleSheet("font-size: 10px;")
+        self.deps_progress_label.setVisible(False)
+        layout.addWidget(self.deps_progress_label)
+
+        self.install_deps_btn = QPushButton("Install Dependencies")
+        self.install_deps_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #1976D2;
+                color: white;
+                font-weight: bold;
+                padding: 6px 12px;
+                border-radius: 4px;
+            }
+            QPushButton:hover {
+                background-color: #1565C0;
+            }
+            QPushButton:disabled {
+                background-color: #BDBDBD;
+            }
+        """)
+        self.install_deps_btn.clicked.connect(self._install_dependencies)
+        layout.addWidget(self.install_deps_btn)
+
+        self.refresh_deps_btn = QPushButton("Refresh Status")
+        self.refresh_deps_btn.clicked.connect(self._refresh_dependency_status)
+        layout.addWidget(self.refresh_deps_btn)
+
+        layout.addStretch()
+
+        note_label = QLabel(
+            "Packages are installed in an isolated environment\n"
+            "(~/.qgis_nasa_opera/) and do not affect your QGIS Python.\n"
+            "If packages are not detected after installation, restart QGIS."
+        )
+        note_label.setWordWrap(True)
+        note_label.setStyleSheet("font-size: 9px; font-style: italic;")
+        layout.addWidget(note_label)
+
+        from qgis.PyQt.QtCore import QTimer
+
+        QTimer.singleShot(100, self._refresh_dependency_status)
+
+        return widget
+
+    def _refresh_dependency_status(self):
+        """Check and display the status of all required dependencies."""
+        from ..deps_manager import check_dependencies
+
+        deps = check_dependencies()
+        all_ok = True
+
+        for dep in deps:
+            label = self.dep_status_labels.get(dep["name"])
+            if label is None:
+                continue
+            if dep["installed"]:
+                version_str = dep["version"] or "installed"
+                label.setText(f"Installed ({version_str})")
+                label.setStyleSheet("color: green; font-weight: bold;")
+            else:
+                label.setText("Not installed")
+                label.setStyleSheet("color: red;")
+                all_ok = False
+
+        if all_ok:
+            self.deps_overall_label.setText("All dependencies are installed.")
+            self.deps_overall_label.setStyleSheet(
+                "color: green; font-weight: bold; padding: 5px;"
+            )
+            self.install_deps_btn.setVisible(False)
+        else:
+            missing_count = sum(1 for d in deps if not d["installed"])
+            self.deps_overall_label.setText(
+                f"{missing_count} package(s) missing. "
+                "Click 'Install Dependencies' to install."
+            )
+            self.deps_overall_label.setStyleSheet(
+                "color: #E65100; font-weight: bold; padding: 5px;"
+            )
+            self.install_deps_btn.setVisible(True)
+            self.install_deps_btn.setEnabled(True)
+
+    def _install_dependencies(self):
+        """Start installing missing dependencies in a background thread."""
+        from ..deps_manager import DepsInstallWorker
+
+        self.install_deps_btn.setEnabled(False)
+        self.install_deps_btn.setText("Installing...")
+        self.refresh_deps_btn.setEnabled(False)
+
+        self.deps_progress_bar.setVisible(True)
+        self.deps_progress_bar.setValue(0)
+        self.deps_progress_label.setVisible(True)
+        self.deps_progress_label.setText("Starting installation...")
+
+        self._deps_worker = DepsInstallWorker()
+        self._deps_worker.progress.connect(self._on_deps_install_progress)
+        self._deps_worker.finished.connect(self._on_deps_install_finished)
+        self._deps_worker.start()
+
+    def _on_deps_install_progress(self, percent, message):
+        """Handle progress updates from the install worker."""
+        self.deps_progress_bar.setValue(percent)
+        self.deps_progress_label.setText(message)
+
+    def _on_deps_install_finished(self, success, message):
+        """Handle completion of dependency installation."""
+        self.deps_progress_bar.setVisible(False)
+        self.deps_progress_label.setVisible(False)
+        self.install_deps_btn.setText("Install Dependencies")
+        self.refresh_deps_btn.setEnabled(True)
+
+        if success:
+            self.deps_overall_label.setText(message)
+            self.deps_overall_label.setStyleSheet(
+                "color: green; font-weight: bold; padding: 5px;"
+            )
+            self.iface.messageBar().pushSuccess(
+                "NASA OPERA", "Dependencies installed successfully!"
+            )
+            self._refresh_dependency_status()
+
+            QMessageBox.information(
+                self,
+                "Dependencies Installed",
+                "Dependencies have been installed successfully.\n\n"
+                "If the plugin does not work immediately, please restart QGIS.",
+            )
+        else:
+            self.deps_overall_label.setText("Installation failed.")
+            self.deps_overall_label.setStyleSheet(
+                "color: red; font-weight: bold; padding: 5px;"
+            )
+            self.install_deps_btn.setEnabled(True)
+
+            QMessageBox.critical(
+                self,
+                "Installation Failed",
+                f"Failed to install dependencies:\n\n{message}\n\n"
+                "You can try installing manually with:\n"
+                "pip install earthaccess geopandas shapely pandas",
+            )
+
+        self._deps_worker = None
+
+    def show_dependencies_tab(self):
+        """Switch to the Dependencies tab programmatically."""
+        self.tab_widget.setCurrentIndex(0)
+        self._refresh_dependency_status()
 
     def _create_credentials_tab(self):
         """Create the credentials settings tab."""

--- a/nasa_opera/metadata.txt
+++ b/nasa_opera/metadata.txt
@@ -29,7 +29,7 @@ about=NASA OPERA Plugin for QGIS provides an intuitive interface for searching a
     - Plugin update checker
 
     Requirements:
-    - Python packages: earthaccess, geopandas, shapely, pandas
+    - Python packages: earthaccess, geopandas, shapely, pandas (installed via Settings > Dependencies)
     - NASA Earthdata account (free registration at https://urs.earthdata.nasa.gov)
 
 tracker=https://github.com/opengeos/qgis-nasa-opera-plugin/issues
@@ -48,7 +48,8 @@ deprecated=False
 
 changelog=
     0.8.2
-        - Remove bundled AI assistant panel and dependency installers
+        - Add Settings > Dependencies one-click dependency installer
+        - Remove bundled AI assistant panel
         - Route the AI Assistant button to OpenGeoAgent
     0.8.1
         - Update AI models in README and LLM client

--- a/nasa_opera/metadata.txt
+++ b/nasa_opera/metadata.txt
@@ -3,7 +3,7 @@ name=NASA OPERA
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Search and visualize NASA OPERA (Observational Products for End-Users from Remote Sensing Analysis) satellite data products.
-version=0.8.2
+version=0.9.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -47,7 +47,7 @@ experimental=False
 deprecated=False
 
 changelog=
-    0.8.2
+    0.9.0
         - Add Settings > Dependencies one-click dependency installer
         - Remove bundled AI assistant panel
         - Route the AI Assistant button to OpenGeoAgent

--- a/nasa_opera/nasa_opera.py
+++ b/nasa_opera/nasa_opera.py
@@ -201,16 +201,23 @@ class NasaOpera:
 
                 if not all_dependencies_met():
                     missing = ", ".join(get_missing_packages())
-                    QMessageBox.warning(
-                        self.iface.mainWindow(),
-                        "Missing Dependencies",
+                    box = QMessageBox(self.iface.mainWindow())
+                    box.setIcon(QMessageBox.Icon.Warning)
+                    box.setWindowTitle("Missing Dependencies")
+                    box.setText(
                         "The NASA OPERA plugin requires additional Python "
                         "packages that are not installed.\n\n"
                         f"Missing packages: {missing}\n\n"
-                        "Install them in the QGIS Python environment, or in "
-                        "an environment available on the QGIS Python path, "
-                        "then restart QGIS.",
+                        "Open Settings > Dependencies to install them in an "
+                        "isolated plugin environment."
                     )
+                    install_button = box.addButton(
+                        "Install Dependencies", QMessageBox.ButtonRole.ActionRole
+                    )
+                    box.addButton(QMessageBox.StandardButton.Ok)
+                    box.exec()
+                    if box.clickedButton() == install_button:
+                        self.show_dependencies_settings()
                     self.opera_action.setChecked(False)
                     return
             except Exception as exc:
@@ -408,6 +415,22 @@ class NasaOpera:
     def _on_settings_visibility_changed(self, visible):
         """Handle Settings dock visibility change."""
         self.settings_action.setChecked(visible)
+
+    def show_dependencies_settings(self):
+        """Open the settings dock on the dependency installer tab."""
+        if self._settings_dock is None:
+            self.toggle_settings_dock()
+
+        if self._settings_dock is not None:
+            if not self._settings_dock.isVisible():
+                self._settings_dock.show()
+            self._settings_dock.raise_()
+            self.settings_action.setChecked(True)
+            show_dependencies_tab = getattr(
+                self._settings_dock, "show_dependencies_tab", None
+            )
+            if callable(show_dependencies_tab):
+                show_dependencies_tab()
 
     def show_about(self):
         """Display the about dialog."""

--- a/nasa_opera/uv_manager.py
+++ b/nasa_opera/uv_manager.py
@@ -1,0 +1,363 @@
+"""
+UV Package Installer Manager for NASA OPERA Plugin.
+
+Downloads and manages the uv package installer binary for fast
+dependency installation in the plugin's virtual environment.
+
+All ``subprocess`` calls in this module use list-form argv built from
+internal constants (the resolved ``uv`` binary path, fixed flags) and
+never accept user-supplied input or run with ``shell=True``. The
+``# nosec`` annotations on the import and call sites document this
+explicitly for the plugins.qgis.org Bandit scan.
+
+Source: https://github.com/astral-sh/uv
+"""
+
+import os
+import sys
+import platform
+import stat
+import subprocess  # nosec B404
+import tarfile
+import zipfile
+import tempfile
+import shutil
+from typing import Callable, Optional, Tuple
+
+from qgis.core import QgsMessageLog, Qgis, QgsBlockingNetworkRequest
+from qgis.PyQt.QtCore import QUrl
+from qgis.PyQt.QtNetwork import QNetworkRequest
+
+CACHE_DIR = os.path.join(os.path.expanduser("~"), ".qgis_nasa_opera")
+UV_DIR = os.path.join(CACHE_DIR, "uv")
+
+# Pin a known-good uv version.
+# Verified platforms: x86_64-pc-windows-msvc, x86_64-apple-darwin,
+# aarch64-apple-darwin, x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu.
+UV_VERSION = "0.10.6"
+
+
+def _log(message, level=Qgis.MessageLevel.Info):
+    """Log a message to the QGIS message log.
+
+    Args:
+        message: The message to log.
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning,
+            Qgis.MessageLevel.Critical).
+    """
+    QgsMessageLog.logMessage(str(message), "NASA OPERA", level=level)
+
+
+def get_uv_path() -> str:
+    """Get the path to the uv binary.
+
+    Returns:
+        The absolute path to the uv executable.
+    """
+    if sys.platform == "win32":
+        return os.path.join(UV_DIR, "uv.exe")
+    return os.path.join(UV_DIR, "uv")
+
+
+def uv_exists() -> bool:
+    """Check if the uv binary is already installed.
+
+    Returns:
+        True if the uv executable exists.
+    """
+    return os.path.exists(get_uv_path())
+
+
+def _get_uv_platform_info() -> Tuple[str, str]:
+    """Get platform and architecture info for the uv download URL.
+
+    Returns:
+        A tuple of (platform_string, file_extension).
+    """
+    system = sys.platform
+    machine = platform.machine().lower()
+
+    if system == "darwin":
+        if machine in ("arm64", "aarch64"):
+            return ("aarch64-apple-darwin", ".tar.gz")
+        return ("x86_64-apple-darwin", ".tar.gz")
+    elif system == "win32":
+        return ("x86_64-pc-windows-msvc", ".zip")
+    else:
+        if machine in ("arm64", "aarch64"):
+            return ("aarch64-unknown-linux-gnu", ".tar.gz")
+        return ("x86_64-unknown-linux-gnu", ".tar.gz")
+
+
+def get_uv_download_url() -> str:
+    """Construct the download URL for the uv binary.
+
+    Returns:
+        The full download URL string.
+    """
+    platform_str, ext = _get_uv_platform_info()
+    filename = f"uv-{platform_str}{ext}"
+    return (
+        f"https://github.com/astral-sh/uv/releases/download/" f"{UV_VERSION}/{filename}"
+    )
+
+
+def _safe_extract_tar(tar, dest_dir):
+    """Safely extract tar archive with path traversal protection.
+
+    Args:
+        tar: An open tarfile.TarFile object.
+        dest_dir: Destination directory for extraction.
+    """
+    dest_dir = os.path.realpath(dest_dir)
+    use_filter = sys.version_info >= (3, 12)
+    for member in tar.getmembers():
+        member_path = os.path.realpath(os.path.join(dest_dir, member.name))
+        if not member_path.startswith(dest_dir + os.sep) and member_path != dest_dir:
+            raise ValueError(f"Attempted path traversal in tar archive: {member.name}")
+        if use_filter:
+            tar.extract(member, dest_dir, filter="data")
+        else:
+            tar.extract(member, dest_dir)
+
+
+def _safe_extract_zip(zip_file, dest_dir):
+    """Safely extract zip archive with path traversal protection.
+
+    Args:
+        zip_file: An open zipfile.ZipFile object.
+        dest_dir: Destination directory for extraction.
+    """
+    dest_dir = os.path.realpath(dest_dir)
+    for member in zip_file.namelist():
+        member_path = os.path.realpath(os.path.join(dest_dir, member))
+        if not member_path.startswith(dest_dir + os.sep) and member_path != dest_dir:
+            raise ValueError(f"Attempted path traversal in zip archive: {member}")
+        zip_file.extract(member, dest_dir)
+
+
+def _find_file_in_dir(directory, filename):
+    """Find a file by name within a directory tree.
+
+    Args:
+        directory: The root directory to search.
+        filename: The filename to find.
+
+    Returns:
+        The full path to the file, or None if not found.
+    """
+    for root, _dirs, files in os.walk(directory):
+        if filename in files:
+            return os.path.join(root, filename)
+    return None
+
+
+def download_uv(
+    progress_callback: Optional[Callable[[int, str], None]] = None,
+    cancel_check: Optional[Callable[[], bool]] = None,
+) -> Tuple[bool, str]:
+    """Download and install the uv binary using QGIS network manager.
+
+    Uses QgsBlockingNetworkRequest to respect QGIS proxy settings.
+
+    Args:
+        progress_callback: Function called with (percent, message) for progress.
+        cancel_check: Function that returns True if operation should be cancelled.
+
+    Returns:
+        A tuple of (success: bool, message: str).
+    """
+    if uv_exists():
+        _log("uv already exists")
+        return True, "uv already installed"
+
+    url = get_uv_download_url()
+    _log(f"Downloading uv {UV_VERSION} from: {url}")
+
+    if progress_callback:
+        progress_callback(0, f"Downloading uv {UV_VERSION}...")
+
+    _, ext = _get_uv_platform_info()
+    fd, temp_path = tempfile.mkstemp(suffix=ext)
+    os.close(fd)
+
+    try:
+        if cancel_check and cancel_check():
+            return False, "Download cancelled"
+
+        request = QgsBlockingNetworkRequest()
+        qurl = QUrl(url)
+
+        if progress_callback:
+            progress_callback(5, "Connecting to download server...")
+
+        err = request.get(QNetworkRequest(qurl))
+
+        if err != QgsBlockingNetworkRequest.NoError:
+            error_msg = request.errorMessage()
+            if "404" in error_msg or "Not Found" in error_msg:
+                error_msg = (
+                    f"uv {UV_VERSION} not available for this platform. " f"URL: {url}"
+                )
+            else:
+                error_msg = f"Download failed: {error_msg}"
+            _log(error_msg, Qgis.MessageLevel.Critical)
+            return False, error_msg
+
+        if cancel_check and cancel_check():
+            return False, "Download cancelled"
+
+        reply = request.reply()
+        content = reply.content()
+
+        if progress_callback:
+            total_mb = len(content) / (1024 * 1024)
+            progress_callback(50, f"Downloaded {total_mb:.1f} MB, saving...")
+
+        with open(temp_path, "wb") as f:
+            f.write(content.data())
+
+        _log(f"Download complete ({len(content)} bytes), extracting...")
+
+        if progress_callback:
+            progress_callback(60, "Extracting uv...")
+
+        if os.path.exists(UV_DIR):
+            shutil.rmtree(UV_DIR)
+        os.makedirs(UV_DIR, exist_ok=True)
+
+        # Extract archive to a temporary directory, then move the binary
+        extract_dir = tempfile.mkdtemp()
+        try:
+            if temp_path.endswith(".zip"):
+                with zipfile.ZipFile(temp_path, "r") as z:
+                    _safe_extract_zip(z, extract_dir)
+            else:
+                with tarfile.open(temp_path, "r:gz") as tar:
+                    _safe_extract_tar(tar, extract_dir)
+
+            # Find the uv binary in the extracted contents
+            uv_binary_name = "uv.exe" if sys.platform == "win32" else "uv"
+            uv_binary = _find_file_in_dir(extract_dir, uv_binary_name)
+
+            if uv_binary is None:
+                found_files = []
+                for root, _dirs, files in os.walk(extract_dir):
+                    found_files.extend(files)
+                    if len(found_files) >= 20:
+                        break
+                files_str = ", ".join(found_files[:20])
+                return False, (
+                    f"uv binary not found in archive. "
+                    f"Expected '{uv_binary_name}'. "
+                    f"Files found (up to 20): {files_str}"
+                )
+
+            dest = get_uv_path()
+            shutil.copy2(uv_binary, dest)
+
+            # Set executable permissions on Unix
+            if sys.platform != "win32":
+                os.chmod(
+                    dest,
+                    stat.S_IRWXU
+                    | stat.S_IRGRP
+                    | stat.S_IXGRP
+                    | stat.S_IROTH
+                    | stat.S_IXOTH,
+                )
+
+        finally:
+            shutil.rmtree(extract_dir, ignore_errors=True)
+
+        if progress_callback:
+            progress_callback(80, "Verifying uv installation...")
+
+        success, verify_msg = verify_uv()
+
+        if success:
+            if progress_callback:
+                progress_callback(100, f"uv {UV_VERSION} installed")
+            _log("uv installed successfully")
+            return True, f"uv {UV_VERSION} installed successfully"
+        else:
+            return False, f"Verification failed: {verify_msg}"
+
+    except InterruptedError:
+        return False, "Download cancelled"
+    except Exception as e:
+        error_msg = f"uv installation failed: {str(e)}"
+        _log(error_msg, Qgis.MessageLevel.Critical)
+        return False, error_msg
+    finally:
+        if os.path.exists(temp_path):
+            try:
+                os.remove(temp_path)
+            except OSError:
+                pass
+
+
+def verify_uv() -> Tuple[bool, str]:
+    """Verify that the uv binary works.
+
+    Returns:
+        A tuple of (success: bool, message: str).
+    """
+    uv_path = get_uv_path()
+
+    if not os.path.exists(uv_path):
+        return False, f"uv not found at {uv_path}"
+
+    try:
+        env = os.environ.copy()
+        env.pop("PYTHONPATH", None)
+        env.pop("PYTHONHOME", None)
+
+        kwargs = {}
+        if sys.platform == "win32":
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            startupinfo.wShowWindow = subprocess.SW_HIDE
+            kwargs["startupinfo"] = startupinfo
+
+        result = subprocess.run(  # nosec B603
+            [uv_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+            **kwargs,
+        )
+
+        if result.returncode == 0:
+            version_output = result.stdout.strip()
+            _log(f"Verified uv: {version_output}")
+            return True, version_output
+        else:
+            error = result.stderr or "Unknown error"
+            _log(f"uv verification failed: {error}", Qgis.MessageLevel.Warning)
+            return False, f"Verification failed: {error[:100]}"
+
+    except subprocess.TimeoutExpired:
+        return False, "uv verification timed out"
+    except Exception as e:
+        return False, f"Verification error: {str(e)[:100]}"
+
+
+def remove_uv() -> Tuple[bool, str]:
+    """Remove the uv installation.
+
+    Returns:
+        A tuple of (success: bool, message: str).
+    """
+    if not os.path.exists(UV_DIR):
+        return True, "uv not installed"
+
+    try:
+        shutil.rmtree(UV_DIR)
+        _log("Removed uv installation")
+        return True, "uv removed"
+    except Exception as e:
+        error_msg = f"Failed to remove uv: {str(e)}"
+        _log(error_msg, Qgis.MessageLevel.Warning)
+        return False, error_msg


### PR DESCRIPTION
## Summary
- Add a Dependencies tab to the Settings dock that creates an isolated venv under `~/.qgis_nasa_opera/` and installs `earthaccess`, `geopandas`, `shapely`, and `pandas` with progress feedback.
- Use `uv` when available (downloaded on demand) for fast installs, falling back to `pip`. Includes Windows-aware logic for finding the real Python interpreter when `sys.executable` is `qgis-bin.exe`.
- Update the missing-dependencies prompt to offer an "Install Dependencies" button that opens the new tab directly. Refresh README and `metadata.txt` accordingly.

## Test plan
- [ ] Load the plugin in QGIS with all packages missing and confirm the warning dialog opens the Dependencies tab.
- [ ] Click "Install Dependencies" and verify the venv is created at `~/.qgis_nasa_opera/venv_pyX.Y` and packages import cleanly after the run.
- [ ] Re-open Settings > Dependencies and confirm all packages report as installed.
- [ ] Repeat on Windows where `sys.executable` may be `qgis-bin.exe`.