### PR TITLE
fix: harden Python executable finder for QGIS launchers

### DIFF
--- a/nasa_opera/deps_manager.py
+++ b/nasa_opera/deps_manager.py
@@ -34,6 +34,7 @@ REQUIRED_PACKAGES = [
 
 CACHE_DIR = os.path.join(os.path.expanduser("~"), ".qgis_nasa_opera")
 PYTHON_VERSION = f"py{sys.version_info.major}.{sys.version_info.minor}"
+INSTALL_TIMEOUT_SECONDS = 1800
 
 
 def get_venv_dir() -> str:
@@ -196,73 +197,160 @@ def _get_subprocess_kwargs() -> dict:
     return {}
 
 
-def _find_python_executable() -> str:
-    """Find a working Python executable for subprocess calls.
+def _is_python_executable_name(path: str) -> bool:
+    """Return True when a path name looks like a Python interpreter."""
+    name = os.path.basename(path).lower()
+    return name in ("python", "python3", "python.exe", "python3.exe") or (
+        name.startswith("python") and name.endswith(".exe")
+    )
 
-    On QGIS Windows, ``sys.executable`` may point to ``qgis-bin.exe`` rather
-    than a Python interpreter, which would launch another QGIS instance when
-    used in subprocess calls. This function searches for the actual Python
-    executable using multiple strategies.
+
+def _python_candidate_matches_runtime(path: str) -> bool:
+    """Return True when a candidate is executable and matches QGIS Python."""
+    if not path or not os.path.isfile(path) or not _is_python_executable_name(path):
+        return False
+
+    try:
+        result = subprocess.run(  # nosec B603
+            [
+                path,
+                "-c",
+                "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=_get_clean_env(),
+            **_get_subprocess_kwargs(),
+        )
+    except Exception:
+        return False
+
+    runtime_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    return result.returncode == 0 and result.stdout.strip() == runtime_version
+
+
+def _candidate_python_paths() -> List[str]:
+    """Return possible Python interpreter paths for QGIS-bundled Python."""
+    candidates = []
+    exe_dir = os.path.dirname(sys.executable)
+    py_ver = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+    for attr in ("_base_executable", "executable"):
+        value = getattr(sys, attr, None)
+        if value:
+            candidates.append(value)
+
+    for attr in ("_base_prefix", "base_prefix", "prefix", "exec_prefix"):
+        prefix = getattr(sys, attr, None)
+        if not prefix:
+            continue
+        candidates.extend(
+            [
+                os.path.join(prefix, "python.exe"),
+                os.path.join(prefix, "bin", "python3"),
+                os.path.join(prefix, "bin", "python"),
+                os.path.join(prefix, "Versions", py_ver, "bin", "python3"),
+                os.path.join(prefix, "Versions", "Current", "bin", "python3"),
+            ]
+        )
+
+    candidates.extend(
+        [
+            os.path.join(exe_dir, "python.exe"),
+            os.path.join(exe_dir, "python3.exe"),
+            os.path.join(exe_dir, "python3"),
+            os.path.join(exe_dir, "python"),
+        ]
+    )
+
+    # QGIS Windows layout:
+    #   .../QGIS 3.x/bin/qgis-bin.exe
+    #   .../QGIS 3.x/apps/Python312/python.exe
+    apps_dir = os.path.join(os.path.dirname(exe_dir), "apps")
+    if os.path.isdir(apps_dir):
+        for entry in sorted(os.listdir(apps_dir), reverse=True):
+            if entry.lower().startswith("python"):
+                candidates.append(os.path.join(apps_dir, entry, "python.exe"))
+
+    # QGIS macOS app layout. Depending on package/version, the launcher may be
+    # Contents/MacOS/QGIS while Python lives under MacOS/bin or Frameworks.
+    current = exe_dir
+    for _ in range(5):
+        if os.path.basename(current) == "Contents":
+            contents_dir = current
+            candidates.extend(
+                [
+                    os.path.join(contents_dir, "MacOS", "bin", "python3"),
+                    os.path.join(contents_dir, "MacOS", "bin", "python"),
+                    os.path.join(
+                        contents_dir,
+                        "Frameworks",
+                        "Python.framework",
+                        "Versions",
+                        py_ver,
+                        "bin",
+                        "python3",
+                    ),
+                    os.path.join(
+                        contents_dir,
+                        "Frameworks",
+                        "Python.framework",
+                        "Versions",
+                        "Current",
+                        "bin",
+                        "python3",
+                    ),
+                    os.path.join(contents_dir, "Resources", "python", "bin", "python3"),
+                ]
+            )
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+
+    for name in ("python3", "python"):
+        which_python = shutil.which(name)
+        if which_python:
+            candidates.append(which_python)
+
+    # Preserve order while removing duplicates.
+    unique = []
+    seen = set()
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            unique.append(candidate)
+            seen.add(candidate)
+    return unique
+
+
+def _find_python_executable() -> str:
+    """Find a real Python executable for subprocess calls.
+
+    QGIS can expose the application launcher as ``sys.executable`` on Windows
+    and macOS. Passing that launcher to uv or venv causes QGIS to receive
+    Python flags such as ``-I`` and ``-c`` as layer/data-source arguments, so
+    this function verifies candidates before returning them.
 
     Returns:
-        Path to a Python executable, or ``sys.executable`` as fallback.
+        Path to a Python executable matching the current QGIS Python version.
+
+    Raises:
+        RuntimeError: If no suitable Python executable can be found.
     """
-    if platform.system() != "Windows":
-        return sys.executable
-
-    # Strategy 1: Check if sys.executable is already Python
-    exe_name = os.path.basename(sys.executable).lower()
-    if exe_name in ("python.exe", "python3.exe"):
-        return sys.executable
-
-    # Strategy 2: Use sys._base_prefix to find the Python installation.
-    # On QGIS Windows, sys._base_prefix typically points to
-    # C:\Program Files\QGIS 3.x\apps\Python3x\
-    base_prefix = getattr(sys, "_base_prefix", None) or sys.prefix
-    python_in_prefix = os.path.join(base_prefix, "python.exe")
-    if os.path.isfile(python_in_prefix):
-        return python_in_prefix
-
-    # Strategy 3: Look for python.exe next to sys.executable
-    exe_dir = os.path.dirname(sys.executable)
-    for name in ("python.exe", "python3.exe"):
-        candidate = os.path.join(exe_dir, name)
-        if os.path.isfile(candidate):
+    for candidate in _candidate_python_paths():
+        if _python_candidate_matches_runtime(candidate):
             return candidate
 
-    # Strategy 4: Walk up from sys.executable to find apps/Python3x/python.exe
-    # Typical QGIS layout: .../QGIS 3.x/bin/qgis-bin.exe
-    #                       .../QGIS 3.x/apps/Python3x/python.exe
-    parent = os.path.dirname(exe_dir)
-    apps_dir = os.path.join(parent, "apps")
-    if os.path.isdir(apps_dir):
-        best_candidate = None
-        best_version_num = -1
-        for entry in os.listdir(apps_dir):
-            lower_entry = entry.lower()
-            if not lower_entry.startswith("python"):
-                continue
-            suffix = lower_entry.removeprefix("python")
-            digits = "".join(ch for ch in suffix if ch.isdigit())
-            if not digits:
-                continue
-            try:
-                version_num = int(digits)
-            except ValueError:
-                continue
-            candidate = os.path.join(apps_dir, entry, "python.exe")
-            if os.path.isfile(candidate) and version_num > best_version_num:
-                best_version_num = version_num
-                best_candidate = candidate
-        if best_candidate:
-            return best_candidate
-
-    # Strategy 5: Use shutil.which as last resort
-    which_python = shutil.which("python")
-    if which_python:
-        return which_python
-
-    return sys.executable
+    candidates = "\n".join(f"  - {path}" for path in _candidate_python_paths())
+    raise RuntimeError(
+        "Could not find a Python executable matching the QGIS Python runtime.\n"
+        f"QGIS sys.executable: {sys.executable}\n"
+        f"Python version: {sys.version_info.major}.{sys.version_info.minor}\n"
+        "Checked candidates:\n"
+        f"{candidates or '  - none'}"
+    )
 
 
 def _create_venv_with_env_builder(venv_dir: str) -> bool:
@@ -561,7 +649,7 @@ def install_packages(
         cmd,
         capture_output=True,
         text=True,
-        timeout=600,
+        timeout=INSTALL_TIMEOUT_SECONDS,
         env=env,
         **kwargs,
     )
@@ -606,6 +694,14 @@ class DepsInstallWorker(QThread):
                     self.progress.emit(5, "uv ready.")
 
             # Step 1: Create venv if needed
+            if venv_exists() and not _python_candidate_matches_runtime(
+                get_venv_python_path(venv_dir)
+            ):
+                self.progress.emit(
+                    5, "Existing virtual environment is invalid, recreating..."
+                )
+                _cleanup_partial_venv(venv_dir)
+
             if not venv_exists():
                 self.progress.emit(5, "Creating virtual environment...")
                 try:
@@ -690,6 +786,9 @@ class DepsInstallWorker(QThread):
                 )
 
         except subprocess.TimeoutExpired:
-            self.finished.emit(False, "Installation timed out after 10 minutes.")
+            minutes = INSTALL_TIMEOUT_SECONDS // 60
+            self.finished.emit(
+                False, f"Installation timed out after {minutes} minutes."
+            )
         except Exception as e:
             self.finished.emit(False, f"Unexpected error: {str(e)}")

--- a/tests/test_deps_manager_python_finder.py
+++ b/tests/test_deps_manager_python_finder.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+
+from nasa_opera import deps_manager
+
+
+def test_find_python_executable_uses_macos_qgis_app_python(tmp_path, monkeypatch):
+    """macOS QGIS may expose the app launcher as sys.executable."""
+    contents_dir = tmp_path / "QGIS.app" / "Contents"
+    qgis_launcher = contents_dir / "MacOS" / "QGIS"
+    bundled_python = contents_dir / "MacOS" / "bin" / "python3"
+
+    qgis_launcher.parent.mkdir(parents=True)
+    qgis_launcher.touch()
+    bundled_python.parent.mkdir(parents=True)
+    bundled_python.touch()
+
+    monkeypatch.setattr(deps_manager.sys, "executable", str(qgis_launcher))
+    monkeypatch.setattr(deps_manager.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        deps_manager,
+        "_python_candidate_matches_runtime",
+        lambda path: Path(path) == bundled_python,
+    )
+
+    assert deps_manager._find_python_executable() == str(bundled_python)
+
+
+def test_find_python_executable_raises_instead_of_returning_qgis_launcher(
+    tmp_path, monkeypatch
+):
+    qgis_launcher = tmp_path / "QGIS.app" / "Contents" / "MacOS" / "QGIS"
+    qgis_launcher.parent.mkdir(parents=True)
+    qgis_launcher.touch()
+
+    monkeypatch.setattr(deps_manager.sys, "executable", str(qgis_launcher))
+    monkeypatch.setattr(deps_manager.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        deps_manager, "_python_candidate_matches_runtime", lambda _path: False
+    )
+
+    with pytest.raises(RuntimeError, match="Could not find a Python executable"):
+        deps_manager._find_python_executable()


### PR DESCRIPTION
## Summary
- Verify Python interpreter candidates against the QGIS Python version so QGIS app launchers (Windows `qgis-bin.exe`, macOS `QGIS.app`) are never returned to `uv`/`venv`.
- Expand candidate search to cover macOS QGIS layouts (`Contents/MacOS/bin/python3`, bundled `Python.framework`) in addition to Windows `apps/PythonXY/`.
- Recreate the managed virtual environment when the cached interpreter no longer matches the running QGIS Python, and raise the install timeout to 30 minutes.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest tests/test_deps_manager_python_finder.py`
- [ ] Trigger a fresh dependency install in QGIS on Windows and macOS to confirm the launcher is no longer used as the interpreter