### PR TITLE
fix: use platform-correct netrc path for Earthdata login

### DIFF
--- a/nasa_opera/dialogs/opera_dock.py
+++ b/nasa_opera/dialogs/opera_dock.py
@@ -66,6 +66,8 @@ from qgis.core import (
 from qgis.PyQt.QtCore import QVariant
 from qgis.gui import QgsMapToolEmitPoint, QgsRubberBand
 
+from nasa_opera.utils.earthdata_credentials import configure_earthdata_netrc_env
+
 # NASA OPERA datasets
 OPERA_DATASETS = {
     "OPERA_L3_DSWX-HLS_V1": {
@@ -434,6 +436,8 @@ def _earthdata_login():
         RuntimeError: If authentication fails (credentials not configured).
     """
     import earthaccess
+
+    configure_earthdata_netrc_env()
 
     auth = None
     for strategy in ("environment", "netrc"):

--- a/nasa_opera/dialogs/settings_dock.py
+++ b/nasa_opera/dialogs/settings_dock.py
@@ -26,6 +26,8 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.PyQt.QtGui import QFont
 
+from nasa_opera.utils.earthdata_credentials import save_earthdata_credentials
+
 
 class SettingsDockWidget(QDockWidget):
     """A settings panel for configuring plugin options."""
@@ -357,7 +359,7 @@ class SettingsDockWidget(QDockWidget):
 
         # Note about netrc
         netrc_label = QLabel(
-            "Note: Credentials are stored in ~/.netrc file for earthaccess."
+            "Note: Credentials are stored in a netrc file for earthaccess."
         )
         netrc_label.setWordWrap(True)
         netrc_label.setStyleSheet("font-size: 9px; font-style: italic;")
@@ -677,48 +679,9 @@ class SettingsDockWidget(QDockWidget):
         )
 
     def _save_to_netrc(self, username, password):
-        """Save credentials to .netrc file for earthaccess."""
-        import os
-        from pathlib import Path
-
-        netrc_path = Path.home() / ".netrc"
-
+        """Save credentials to a netrc file for earthaccess."""
         try:
-            # Read existing content
-            existing_lines = []
-            if netrc_path.exists():
-                with open(netrc_path, "r") as f:
-                    existing_lines = f.readlines()
-
-            # Remove existing earthdata entry
-            new_lines = []
-            skip_machine = False
-            for line in existing_lines:
-                if line.strip().startswith("machine urs.earthdata.nasa.gov"):
-                    skip_machine = True
-                    continue
-                if (
-                    skip_machine
-                    and line.strip()
-                    and not line.strip().startswith("machine")
-                ):
-                    continue
-                skip_machine = False
-                new_lines.append(line)
-
-            # Add new entry
-            new_lines.append(
-                f"\nmachine urs.earthdata.nasa.gov login {username} password {password}\n"
-            )
-
-            # Write file
-            with open(netrc_path, "w") as f:
-                f.writelines(new_lines)
-
-            # Set permissions (Unix-like systems)
-            if os.name != "nt":
-                os.chmod(netrc_path, 0o600)
-
+            save_earthdata_credentials(username, password)
         except Exception as e:
             QMessageBox.warning(
                 self,

--- a/nasa_opera/metadata.txt
+++ b/nasa_opera/metadata.txt
@@ -3,7 +3,7 @@ name=NASA OPERA
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Search and visualize NASA OPERA (Observational Products for End-Users from Remote Sensing Analysis) satellite data products.
-version=0.9.0
+version=0.9.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -47,6 +47,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.9.1
+        - Fix Earthdata netrc credential reuse on Windows
     0.9.0
         - Add Settings > Dependencies one-click dependency installer
         - Remove bundled AI assistant panel

--- a/nasa_opera/utils/earthdata_credentials.py
+++ b/nasa_opera/utils/earthdata_credentials.py
@@ -1,0 +1,85 @@
+"""Helpers for Earthdata credential storage."""
+
+import os
+import sys
+from pathlib import Path
+
+EARTHDATA_MACHINE = "urs.earthdata.nasa.gov"
+
+
+def _is_windows(platform=None):
+    """Return True when paths should follow Windows netrc conventions."""
+    return (platform or sys.platform).startswith("win")
+
+
+def earthdata_netrc_paths(home=None, platform=None):
+    """Return netrc paths in the order earthaccess should try them."""
+    home_path = Path(home) if home is not None else Path.home()
+    if _is_windows(platform):
+        return [home_path / "_netrc", home_path / ".netrc"]
+    return [home_path / ".netrc"]
+
+
+def default_earthdata_netrc_path(home=None, platform=None):
+    """Return the platform-default netrc path for writing credentials."""
+    return earthdata_netrc_paths(home=home, platform=platform)[0]
+
+
+def configure_earthdata_netrc_env(home=None, platform=None):
+    """Point earthaccess at the configured netrc file when one exists.
+
+    Earthaccess defaults to ``~/_netrc`` on Windows, while older versions of
+    this plugin saved ``~/.netrc`` on every platform. Setting ``NETRC`` lets
+    existing Windows installs keep working without asking for the password
+    again.
+    """
+    configured_path = os.environ.get("NETRC")
+    if configured_path:
+        return Path(configured_path).expanduser()
+
+    for netrc_path in earthdata_netrc_paths(home=home, platform=platform):
+        if netrc_path.exists():
+            os.environ["NETRC"] = str(netrc_path)
+            return netrc_path
+
+    return None
+
+
+def save_earthdata_credentials(username, password, home=None, platform=None):
+    """Save Earthdata credentials and return the path used."""
+    netrc_path = default_earthdata_netrc_path(home=home, platform=platform)
+    existing_lines = []
+    if netrc_path.exists():
+        with open(netrc_path, "r", encoding="utf-8") as f:
+            existing_lines = f.readlines()
+
+    new_lines = []
+    skip_machine = False
+    for line in existing_lines:
+        stripped = line.strip()
+        if stripped.startswith(f"machine {EARTHDATA_MACHINE}"):
+            skip_machine = True
+            continue
+        if skip_machine and stripped and not stripped.startswith("machine"):
+            continue
+        skip_machine = False
+        new_lines.append(line)
+
+    if new_lines and new_lines[-1].strip():
+        new_lines.append("\n")
+    new_lines.extend(
+        [
+            f"machine {EARTHDATA_MACHINE}\n",
+            f"  login {username}\n",
+            f"  password {password}\n",
+        ]
+    )
+
+    with open(netrc_path, "w", encoding="utf-8") as f:
+        f.writelines(new_lines)
+
+    if not _is_windows(platform):
+        os.chmod(netrc_path, 0o600)
+
+    os.environ["NETRC"] = str(netrc_path)
+    return netrc_path

--- a/tests/test_earthdata_credentials.py
+++ b/tests/test_earthdata_credentials.py
@@ -1,0 +1,68 @@
+import os
+
+from nasa_opera.utils.earthdata_credentials import (
+    configure_earthdata_netrc_env,
+    earthdata_netrc_paths,
+    save_earthdata_credentials,
+)
+
+
+def test_windows_netrc_paths_prefer_underscore_name(tmp_path):
+    assert earthdata_netrc_paths(home=tmp_path, platform="win32") == [
+        tmp_path / "_netrc",
+        tmp_path / ".netrc",
+    ]
+
+
+def test_configure_netrc_env_uses_existing_windows_dot_netrc(tmp_path, monkeypatch):
+    dot_netrc = tmp_path / ".netrc"
+    dot_netrc.write_text(
+        "machine urs.earthdata.nasa.gov login user password pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("NETRC", raising=False)
+
+    selected = configure_earthdata_netrc_env(home=tmp_path, platform="win32")
+
+    assert selected == dot_netrc
+    assert os.environ["NETRC"] == str(dot_netrc)
+
+
+def test_save_earthdata_credentials_writes_windows_default_netrc(tmp_path, monkeypatch):
+    monkeypatch.delenv("NETRC", raising=False)
+
+    selected = save_earthdata_credentials(
+        "new-user", "new-pass", home=tmp_path, platform="win32"
+    )
+
+    assert selected == tmp_path / "_netrc"
+    assert os.environ["NETRC"] == str(selected)
+    assert selected.read_text(encoding="utf-8") == (
+        "machine urs.earthdata.nasa.gov\n" "  login new-user\n" "  password new-pass\n"
+    )
+
+
+def test_save_earthdata_credentials_replaces_existing_entry(tmp_path, monkeypatch):
+    netrc_path = tmp_path / ".netrc"
+    netrc_path.write_text(
+        "machine example.com\n"
+        "  login other\n"
+        "  password secret\n"
+        "machine urs.earthdata.nasa.gov\n"
+        "  login old-user\n"
+        "  password old-pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("NETRC", raising=False)
+
+    save_earthdata_credentials("new-user", "new-pass", home=tmp_path, platform="linux")
+
+    assert netrc_path.read_text(encoding="utf-8") == (
+        "machine example.com\n"
+        "  login other\n"
+        "  password secret\n"
+        "\n"
+        "machine urs.earthdata.nasa.gov\n"
+        "  login new-user\n"
+        "  password new-pass\n"
+    )


### PR DESCRIPTION
## Summary
- Centralize Earthdata netrc handling in `nasa_opera/utils/earthdata_credentials.py` so the settings dock writes to the platform default (`_netrc` on Windows, `.netrc` elsewhere) that `earthaccess` actually reads.
- Before logging in, point `NETRC` at any existing netrc file so users who saved credentials with the previous version keep working without re-entering their password.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest tests/test_earthdata_credentials.py`
- [ ] Manually save credentials from the Settings dock on Windows and confirm Earthdata login succeeds without prompting again.