### PR TITLE
Fix macOS QGIS dependency installer

### DIFF
--- a/nasa_opera/deps_manager.py
+++ b/nasa_opera/deps_manager.py
@@ -206,7 +206,7 @@ def _is_python_executable_name(path: str) -> bool:
 
 
 def _is_macos_qgis_app_bundle_python(path: str) -> bool:
-    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    """Return True for unsafe Python launchers in QGIS.app/Contents/MacOS."""
     if not (platform.system() == "Darwin" or sys.platform == "darwin"):
         return False
     parts = os.path.abspath(path).split(os.sep)
@@ -214,7 +214,12 @@ def _is_macos_qgis_app_bundle_python(path: str) -> bool:
         lower = part.lower()
         if not (lower.startswith("qgis") and lower.endswith(".app")):
             continue
-        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+        if idx + 2 >= len(parts):
+            return False
+        if parts[idx + 1].lower() != "contents" or parts[idx + 2].lower() != "macos":
+            return False
+        name = os.path.basename(path).lower()
+        return name.startswith("qgis") or _is_python_executable_name(path)
     return False
 
 
@@ -530,6 +535,7 @@ def create_venv(venv_dir: str) -> str:
     # Strategy 0: Use uv venv when available (fastest, no pip needed). On
     # official macOS QGIS app bundles, require uv-managed Python instead of
     # reusing QGIS's app-bundle Python wrapper for venv creation.
+    uv_error = ""
     if uv_exists():
         uv_path = get_uv_path()
         uv_python = python_exe or f"{sys.version_info.major}.{sys.version_info.minor}"
@@ -547,13 +553,17 @@ def create_venv(venv_dir: str) -> str:
         )
         if result.returncode == 0 and os.path.isfile(python_path):
             return python_path
+        uv_error = result.stderr or result.stdout or f"exit code {result.returncode}"
         # uv venv failed — clean up and fall through to pip strategies
         _cleanup_partial_venv(venv_dir)
 
     # Strategy 1: Subprocess with the real Python executable
     subprocess_error = ""
     if python_exe is None:
-        raise RuntimeError(python_lookup_error)
+        message = python_lookup_error or "No usable Python executable was found."
+        if uv_error:
+            message += f"\nuv venv failed: {uv_error}"
+        raise RuntimeError(message)
 
     cmd = [python_exe, "-m", "venv", venv_dir]
     result = subprocess.run(  # nosec B603

--- a/nasa_opera/deps_manager.py
+++ b/nasa_opera/deps_manager.py
@@ -205,9 +205,25 @@ def _is_python_executable_name(path: str) -> bool:
     )
 
 
+def _is_macos_qgis_app_bundle_python(path: str) -> bool:
+    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    if not (platform.system() == "Darwin" or sys.platform == "darwin"):
+        return False
+    parts = os.path.abspath(path).split(os.sep)
+    for idx, part in enumerate(parts):
+        lower = part.lower()
+        if not (lower.startswith("qgis") and lower.endswith(".app")):
+            continue
+        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+    return False
+
+
 def _python_candidate_matches_runtime(path: str) -> bool:
     """Return True when a candidate is executable and matches QGIS Python."""
     if not path or not os.path.isfile(path) or not _is_python_executable_name(path):
+        return False
+
+    if _is_macos_qgis_app_bundle_python(path):
         return False
 
     try:
@@ -504,11 +520,23 @@ def create_venv(venv_dir: str) -> str:
     env = _get_clean_env()
     kwargs = _get_subprocess_kwargs()
 
-    # Strategy 0: Use uv venv when available (fastest, no pip needed)
+    python_exe = None
+    python_lookup_error = ""
+    try:
+        python_exe = _find_python_executable()
+    except RuntimeError as exc:
+        python_lookup_error = str(exc)
+
+    # Strategy 0: Use uv venv when available (fastest, no pip needed). On
+    # official macOS QGIS app bundles, require uv-managed Python instead of
+    # reusing QGIS's app-bundle Python wrapper for venv creation.
     if uv_exists():
         uv_path = get_uv_path()
-        python_exe = _find_python_executable()
-        cmd = [uv_path, "venv", "--python", python_exe, venv_dir]
+        uv_python = python_exe or f"{sys.version_info.major}.{sys.version_info.minor}"
+        cmd = [uv_path, "venv"]
+        if python_exe is None:
+            cmd.append("--managed-python")
+        cmd += ["--python", uv_python, venv_dir]
         result = subprocess.run(  # nosec B603
             cmd,
             capture_output=True,
@@ -523,8 +551,9 @@ def create_venv(venv_dir: str) -> str:
         _cleanup_partial_venv(venv_dir)
 
     # Strategy 1: Subprocess with the real Python executable
-    python_exe = _find_python_executable()
     subprocess_error = ""
+    if python_exe is None:
+        raise RuntimeError(python_lookup_error)
 
     cmd = [python_exe, "-m", "venv", venv_dir]
     result = subprocess.run(  # nosec B603

--- a/nasa_opera/metadata.txt
+++ b/nasa_opera/metadata.txt
@@ -46,7 +46,9 @@ icon=icons/opera.svg
 experimental=False
 deprecated=False
 
-changelog=Fix macOS QGIS installer dependency installation and bump patch version.
+changelog=
+    0.9.2
+        - Fix macOS QGIS installer dependency installation
     0.9.1
         - Fix Earthdata netrc credential reuse on Windows
     0.9.0

--- a/nasa_opera/metadata.txt
+++ b/nasa_opera/metadata.txt
@@ -46,7 +46,7 @@ icon=icons/opera.svg
 experimental=False
 deprecated=False
 
-changelog=
+changelog=Fix macOS QGIS installer dependency installation and bump patch version.
     0.9.1
         - Fix Earthdata netrc credential reuse on Windows
     0.9.0

--- a/nasa_opera/metadata.txt
+++ b/nasa_opera/metadata.txt
@@ -3,7 +3,7 @@ name=NASA OPERA
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Search and visualize NASA OPERA (Observational Products for End-Users from Remote Sensing Analysis) satellite data products.
-version=0.9.1
+version=0.9.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 


### PR DESCRIPTION
## Summary
- Reject macOS QGIS app-bundle Python wrappers for dependency virtual environment creation where this plugin manages dependency venvs.
- Use uv-managed Python when no safe local Python interpreter is available.
- Bump the QGIS plugin patch version in `metadata.txt`.

## Root Cause
Official macOS QGIS installer builds can expose Python wrappers inside `QGIS*.app/Contents/MacOS` that either fail to start outside QGIS or create virtual environments pointing at the QGIS CI build prefix. Those venvs fail during dependency installation with missing stdlib modules such as `encodings`.

## Validation
- `python -m py_compile` on the changed dependency manager
- Focused local QGIS plugin tests were run from the source checkout before publishing these PRs.
