### PR TITLE
[codex] Fix QGIS plugin reload cleanup

### DIFF
--- a/nasa_opera/nasa_opera.py
+++ b/nasa_opera/nasa_opera.py
@@ -18,6 +18,7 @@ OPEN_GEOAGENT_PLUGIN_CANDIDATES = ("open_geoagent",)
 TOOLBAR_OBJECT_NAME = "NasaOperaToolbar"
 MENU_TITLE = "&NASA OPERA"
 
+
 class NasaOpera:
     """NASA OPERA implementation class for QGIS."""
 
@@ -171,7 +172,6 @@ class NasaOpera:
             status_tip="About NASA OPERA Plugin",
             parent=self.iface.mainWindow(),
         )
-
 
     def _remove_toolbar(self, toolbar):
         """Detach and schedule deletion of a plugin toolbar widget."""

--- a/nasa_opera/nasa_opera.py
+++ b/nasa_opera/nasa_opera.py
@@ -15,6 +15,9 @@ from qgis.PyQt.QtWidgets import QAction, QMenu, QToolBar, QMessageBox
 OPEN_GEOAGENT_PLUGIN_CANDIDATES = ("open_geoagent",)
 
 
+TOOLBAR_OBJECT_NAME = "NasaOperaToolbar"
+MENU_TITLE = "&NASA OPERA"
+
 class NasaOpera:
     """NASA OPERA implementation class for QGIS."""
 
@@ -83,13 +86,15 @@ class NasaOpera:
 
     def initGui(self):
         """Create the menu entries and toolbar icons inside the QGIS GUI."""
+        self._remove_toolbars_by_object_name()
+        self._remove_menus_by_title()
         # Create menu
         self.menu = QMenu("&NASA OPERA")
         self.iface.mainWindow().menuBar().addMenu(self.menu)
 
         # Create toolbar
         self.toolbar = QToolBar("NASA OPERA Toolbar")
-        self.toolbar.setObjectName("NasaOperaToolbar")
+        self.toolbar.setObjectName(TOOLBAR_OBJECT_NAME)
         self.iface.addToolBar(self.toolbar)
 
         # Get icon paths
@@ -167,6 +172,93 @@ class NasaOpera:
             parent=self.iface.mainWindow(),
         )
 
+
+    def _remove_toolbar(self, toolbar):
+        """Detach and schedule deletion of a plugin toolbar widget."""
+        if toolbar is None:
+            return
+
+        main_window = self.iface.mainWindow()
+        actions = []
+        try:
+            actions = list(toolbar.actions())
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.clear()
+        except Exception:
+            pass  # nosec B110
+        for action in actions:
+            try:
+                action.deleteLater()
+            except Exception:
+                pass  # nosec B110
+        try:
+            main_window.removeToolBar(toolbar)
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.hide()
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_toolbars_by_object_name(self):
+        """Remove current or stale plugin toolbars from QGIS."""
+        main_window = self.iface.mainWindow()
+        for toolbar in main_window.findChildren(QToolBar, TOOLBAR_OBJECT_NAME):
+            self._remove_toolbar(toolbar)
+
+    def _plugin_menu_titles(self):
+        """Return possible translated and untranslated plugin menu titles."""
+        titles = {MENU_TITLE}
+        translator = getattr(self, "tr", None)
+        if callable(translator):
+            try:
+                titles.add(translator(MENU_TITLE))
+            except Exception:
+                pass  # nosec B110
+        return titles
+
+    def _remove_menu(self, menu):
+        """Detach and schedule deletion of a plugin menu."""
+        if menu is None:
+            return
+
+        main_window = self.iface.mainWindow()
+        try:
+            menu.clear()
+        except Exception:
+            pass  # nosec B110
+        try:
+            main_window.menuBar().removeAction(menu.menuAction())
+        except Exception:
+            pass  # nosec B110
+        try:
+            menu.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            menu.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_menus_by_title(self):
+        """Remove current or stale plugin menus from QGIS."""
+        menu_bar = self.iface.mainWindow().menuBar()
+        titles = self._plugin_menu_titles()
+        for action in menu_bar.actions():
+            menu = action.menu()
+            if menu is not None and menu.title() in titles:
+                self._remove_menu(menu)
+
     def unload(self):
         """Remove the plugin menu item and icon from QGIS GUI."""
         # Remove dock widgets
@@ -191,6 +283,9 @@ class NasaOpera:
         # Remove menu
         if self.menu:
             self.menu.deleteLater()
+
+        self._remove_toolbars_by_object_name()
+        self._remove_menus_by_title()
 
     def toggle_opera_dock(self):
         """Toggle the NASA OPERA dock widget visibility."""


### PR DESCRIPTION
## Summary

Fix QGIS Plugin Reloader warnings caused by custom plugin toolbars and menus that can remain attached to the QGIS main window after `unload()`.

## Changes

- Remove stale plugin toolbars by object name before creating a new toolbar.
- Detach and schedule stale toolbars for deletion during unload.
- Remove stale plugin menus by title before initialization and during unload.
- Keep cleanup best-effort so reload/unload can continue even if QGIS has already detached a widget.

## Validation

- Ran `python -m py_compile` on the changed plugin entry-point file.
- Ran `git diff --check`.
